### PR TITLE
Remove dependency on byteorder crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ homepage = "https://github.com/bojand/infer"
 repository = "https://github.com/bojand/infer"
 documentation = "https://github.com/bojand/infer"
 exclude = ["testdata/*", "tests/*"]
-
-[dependencies]
-byteorder = "1"

--- a/src/matchers/doc.rs
+++ b/src/matchers/doc.rs
@@ -1,6 +1,4 @@
-extern crate byteorder;
-
-use byteorder::{ByteOrder, LittleEndian};
+use std::convert::TryInto;
 
 #[derive(Debug, Eq, PartialEq)]
 enum DocType {
@@ -98,7 +96,7 @@ fn msooxml(buf: &[u8]) -> Option<DocType> {
     // skip to the second local file header
     // since some documents include a 520-byte extra field following the file
     // header, we need to scan for the next header
-    let mut start_offset = (LittleEndian::read_u32(&buf[18..22]) + 49) as usize;
+    let mut start_offset = (u32::from_le_bytes(buf[18..22].try_into().unwrap()) + 49) as usize;
     let idx = search(buf, start_offset, 6000)?;
 
     // now skip to the *third* local file header; again, we need to scan due to a

--- a/src/matchers/image.rs
+++ b/src/matchers/image.rs
@@ -1,6 +1,4 @@
-extern crate byteorder;
-
-use byteorder::{BigEndian, ByteOrder};
+use std::convert::TryInto;
 use std::str;
 
 /// Returns whether a buffer is JPEG image data.
@@ -124,7 +122,7 @@ fn is_isobmff(buf: &[u8]) -> bool {
         return false;
     }
 
-    let ftyp_length = BigEndian::read_u32(&buf[0..4]) as usize;
+    let ftyp_length = u32::from_be_bytes(buf[0..4].try_into().unwrap()) as usize;
     buf.len() >= ftyp_length
 }
 
@@ -134,7 +132,7 @@ fn get_ftyp(buf: &[u8]) -> Option<(String, String, Vec<String>)> {
         return None;
     }
 
-    let ftyp_length = BigEndian::read_u32(&buf[0..4]) as usize;
+    let ftyp_length = u32::from_be_bytes(buf[0..4].try_into().unwrap()) as usize;
 
     let major_str = str::from_utf8(&buf[8..12]);
     let minor_str = str::from_utf8(&buf[12..16]);


### PR DESCRIPTION
Replaces the byteorder crate with the std `from_le_bytes` and `from_be_bytes` methods introduced in Rust 1.32.0