### PR TITLE
Refactor infer::Type and iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,12 @@ impl fmt::Debug for Type {
     }
 }
 
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.mime_type, f)
+    }
+}
+
 impl PartialEq for Type {
     fn eq(&self, other: &Self) -> bool {
         self.matcher_type == other.matcher_type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ impl Type {
 
 impl fmt::Debug for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Kind")
+        f.debug_struct("Type")
             .field("matcher_type", &self.matcher_type)
             .field("mime_type", &self.mime_type)
             .field("extension", &self.extension)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub struct Type {
 }
 
 impl Type {
-    pub(crate) const fn new(
+    pub(crate) const fn new_static(
         matcher_type: MatcherType,
         mime_type: &'static str,
         extension: &'static str,
@@ -101,18 +101,14 @@ impl Type {
         }
     }
 
-    /// Only for tests
-    #[doc(hidden)]
-    pub fn new_for_test(
+    /// Returns a new `Type` with matcher and extension.
+    pub fn new(
         matcher_type: MatcherType,
         mime_type: &'static str,
         extension: &'static str,
+        matcher: Matcher,
     ) -> Self {
-        fn matcher(_buf: &[u8]) -> bool {
-            false
-        };
-
-        Self::new(matcher_type, mime_type, extension, WrapMatcher(matcher))
+        Self::new_static(matcher_type, mime_type, extension, WrapMatcher(matcher))
     }
 
     /// Returns the type of matcher
@@ -349,7 +345,7 @@ impl Infer {
     /// assert_eq!("foo", res.extension());
     /// ```
     pub fn add(&mut self, mime_type: &'static str, extension: &'static str, m: Matcher) {
-        self.mmap.push(Type::new(
+        self.mmap.push(Type::new_static(
             MatcherType::CUSTOM,
             mime_type,
             extension,

--- a/src/map.rs
+++ b/src/map.rs
@@ -21,7 +21,7 @@ pub struct WrapMatcher(pub Matcher);
 macro_rules! matcher_map {
     ($(($mtype:expr, $mime_type:literal, $extension:literal, $matcher:expr)),*) => {
         pub const MATCHER_MAP: &[Type] = &[
-            $(Type::new($mtype, $mime_type, $extension, WrapMatcher($matcher)),)*
+            $(Type::new_static($mtype, $mime_type, $extension, WrapMatcher($matcher)),)*
         ];
     };
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,6 @@
-use super::matchers;
-use super::Matcher;
+use super::{matchers, Matcher, Type};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MatcherType {
     APP,
     ARCHIVE,
@@ -19,9 +18,9 @@ pub enum MatcherType {
 pub struct WrapMatcher(pub Matcher);
 
 macro_rules! matcher_map {
-    ($(($mtype:expr, $mime:literal, $ext:literal, $matcher:expr)),*) => {
-        pub const MATCHER_MAP: &[(MatcherType, &'static str, &'static str, WrapMatcher)] = &[
-            $(($mtype, $mime, $ext, WrapMatcher($matcher as Matcher)),)*
+    ($(($mtype:expr, $mime_type:literal, $extension:literal, $matcher:expr)),*) => {
+        pub const MATCHER_MAP: &[(Type, WrapMatcher)] = &[
+            $((Type::new($mtype, $mime_type, $extension), WrapMatcher($matcher)),)*
         ];
     };
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -15,12 +15,13 @@ pub enum MatcherType {
 // This is needed until function pointers can be used in `const fn`.
 // See trick and discussion at https://github.com/rust-lang/rust/issues/63997#issuecomment-616666309
 #[repr(transparent)]
+#[derive(Copy, Clone)]
 pub struct WrapMatcher(pub Matcher);
 
 macro_rules! matcher_map {
     ($(($mtype:expr, $mime_type:literal, $extension:literal, $matcher:expr)),*) => {
-        pub const MATCHER_MAP: &[(Type, WrapMatcher)] = &[
-            $((Type::new($mtype, $mime_type, $extension), WrapMatcher($matcher)),)*
+        pub const MATCHER_MAP: &[Type] = &[
+            $(Type::new($mtype, $mime_type, $extension, WrapMatcher($matcher)),)*
         ];
     };
 }

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -5,7 +5,7 @@ fn test_elf() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::APP, "application/x-executable", "elf",),
+        Type::new_for_test(MatcherType::APP, "application/x-executable", "elf",),
         info.get_from_path("testdata/sample_elf").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_exe() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(
+        Type::new_for_test(
             MatcherType::APP,
             "application/vnd.microsoft.portable-executable",
             "exe",
@@ -28,7 +28,7 @@ fn test_exe() {
 fn test_wasm() {
     let info = Infer::new();
     assert_eq!(
-        Type::new(MatcherType::APP, "application/wasm", "wasm",),
+        Type::new_for_test(MatcherType::APP, "application/wasm", "wasm",),
         info.get_from_path("testdata/sample.wasm").unwrap().unwrap()
     );
 }

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,15 +1,34 @@
-extern crate infer;
+use infer::{Infer, MatcherType, Type};
 
-use infer::Infer;
+#[test]
+fn test_elf() {
+    let info = Infer::new();
+
+    assert_eq!(
+        Type::new(MatcherType::APP, "application/x-executable", "elf",),
+        info.get_from_path("testdata/sample_elf").unwrap().unwrap()
+    );
+}
+
+#[test]
+fn test_exe() {
+    let info = Infer::new();
+
+    assert_eq!(
+        Type::new(
+            MatcherType::APP,
+            "application/vnd.microsoft.portable-executable",
+            "exe",
+        ),
+        info.get_from_path("testdata/sample.exe").unwrap().unwrap()
+    );
+}
 
 #[test]
 fn test_wasm() {
     let info = Infer::new();
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/wasm"),
-            ext: String::from("wasm"),
-        },
+        Type::new(MatcherType::APP, "application/wasm", "wasm",),
         info.get_from_path("testdata/sample.wasm").unwrap().unwrap()
     );
 }

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,11 +1,15 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_elf() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::APP, "application/x-executable", "elf"),
+        Type::new(MatcherType::APP, "application/x-executable", "elf", matcher),
         info.get_from_path("testdata/sample_elf").unwrap().unwrap()
     );
 }
@@ -15,10 +19,11 @@ fn test_exe() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(
+        Type::new(
             MatcherType::APP,
             "application/vnd.microsoft.portable-executable",
             "exe",
+            matcher
         ),
         info.get_from_path("testdata/sample.exe").unwrap().unwrap()
     );
@@ -28,7 +33,7 @@ fn test_exe() {
 fn test_wasm() {
     let info = Infer::new();
     assert_eq!(
-        Type::new_for_test(MatcherType::APP, "application/wasm", "wasm"),
+        Type::new(MatcherType::APP, "application/wasm", "wasm", matcher),
         info.get_from_path("testdata/sample.wasm").unwrap().unwrap()
     );
 }

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -5,7 +5,7 @@ fn test_elf() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::APP, "application/x-executable", "elf",),
+        Type::new_for_test(MatcherType::APP, "application/x-executable", "elf"),
         info.get_from_path("testdata/sample_elf").unwrap().unwrap()
     );
 }
@@ -28,7 +28,7 @@ fn test_exe() {
 fn test_wasm() {
     let info = Infer::new();
     assert_eq!(
-        Type::new_for_test(MatcherType::APP, "application/wasm", "wasm",),
+        Type::new_for_test(MatcherType::APP, "application/wasm", "wasm"),
         info.get_from_path("testdata/sample.wasm").unwrap().unwrap()
     );
 }

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -5,7 +5,7 @@ fn test_sqlite() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::ARCHIVE, "application/vnd.sqlite3", "sqlite",),
+        Type::new_for_test(MatcherType::ARCHIVE, "application/vnd.sqlite3", "sqlite"),
         info.get_from_path("testdata/sample.db").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_zst() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::ARCHIVE, "application/zstd", "zst",),
+        Type::new_for_test(MatcherType::ARCHIVE, "application/zstd", "zst"),
         info.get_from_path("testdata/sample.tar.zst")
             .unwrap()
             .unwrap()

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -5,7 +5,7 @@ fn test_sqlite() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::ARCHIVE, "application/vnd.sqlite3", "sqlite",),
+        Type::new_for_test(MatcherType::ARCHIVE, "application/vnd.sqlite3", "sqlite",),
         info.get_from_path("testdata/sample.db").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_zst() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::ARCHIVE, "application/zstd", "zst",),
+        Type::new_for_test(MatcherType::ARCHIVE, "application/zstd", "zst",),
         info.get_from_path("testdata/sample.tar.zst")
             .unwrap()
             .unwrap()

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,42 +1,11 @@
-extern crate infer;
-
-use infer::Infer;
-
-#[test]
-fn test_exe() {
-    let info = Infer::new();
-
-    assert_eq!(
-        infer::Type {
-            mime: String::from("application/vnd.microsoft.portable-executable"),
-            ext: String::from("exe"),
-        },
-        info.get_from_path("testdata/sample.exe").unwrap().unwrap()
-    );
-}
-
-#[test]
-fn test_elf() {
-    let info = Infer::new();
-
-    assert_eq!(
-        infer::Type {
-            mime: String::from("application/x-executable"),
-            ext: String::from("elf"),
-        },
-        info.get_from_path("testdata/sample_elf").unwrap().unwrap()
-    );
-}
+use infer::{Infer, MatcherType, Type};
 
 #[test]
 fn test_sqlite() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/vnd.sqlite3"),
-            ext: String::from("sqlite"),
-        },
+        Type::new(MatcherType::ARCHIVE, "application/vnd.sqlite3", "sqlite",),
         info.get_from_path("testdata/sample.db").unwrap().unwrap()
     );
 }
@@ -46,10 +15,7 @@ fn test_zst() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/zstd"),
-            ext: String::from("zst"),
-        },
+        Type::new(MatcherType::ARCHIVE, "application/zstd", "zst",),
         info.get_from_path("testdata/sample.tar.zst")
             .unwrap()
             .unwrap()

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,11 +1,20 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_sqlite() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::ARCHIVE, "application/vnd.sqlite3", "sqlite"),
+        Type::new(
+            MatcherType::ARCHIVE,
+            "application/vnd.sqlite3",
+            "sqlite",
+            matcher
+        ),
         info.get_from_path("testdata/sample.db").unwrap().unwrap()
     );
 }
@@ -15,7 +24,7 @@ fn test_zst() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::ARCHIVE, "application/zstd", "zst"),
+        Type::new(MatcherType::ARCHIVE, "application/zstd", "zst", matcher),
         info.get_from_path("testdata/sample.tar.zst")
             .unwrap()
             .unwrap()

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -5,7 +5,7 @@ fn test_mp3() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::AUDIO, "audio/mpeg", "mp3",),
+        Type::new_for_test(MatcherType::AUDIO, "audio/mpeg", "mp3"),
         info.get_from_path("testdata/sample.mp3").unwrap().unwrap()
     );
 }

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,11 +1,15 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_mp3() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::AUDIO, "audio/mpeg", "mp3"),
+        Type::new(MatcherType::AUDIO, "audio/mpeg", "mp3", matcher),
         info.get_from_path("testdata/sample.mp3").unwrap().unwrap()
     );
 }

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -5,7 +5,7 @@ fn test_mp3() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::AUDIO, "audio/mpeg", "mp3",),
+        Type::new_for_test(MatcherType::AUDIO, "audio/mpeg", "mp3",),
         info.get_from_path("testdata/sample.mp3").unwrap().unwrap()
     );
 }

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,16 +1,11 @@
-extern crate infer;
-
-use infer::Infer;
+use infer::{Infer, MatcherType, Type};
 
 #[test]
 fn test_mp3() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("audio/mpeg"),
-            ext: String::from("mp3"),
-        },
+        Type::new(MatcherType::AUDIO, "audio/mpeg", "mp3",),
         info.get_from_path("testdata/sample.mp3").unwrap().unwrap()
     );
 }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -1,11 +1,15 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_doc() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::DOC, "application/msword", "doc"),
+        Type::new(MatcherType::DOC, "application/msword", "doc", matcher),
         info.get_from_path("testdata/sample.doc").unwrap().unwrap()
     );
 }
@@ -15,10 +19,11 @@ fn test_docx() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(
+        Type::new(
             MatcherType::DOC,
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "docx",
+            matcher
         ),
         info.get_from_path("testdata/sample.docx").unwrap().unwrap()
     );
@@ -29,10 +34,11 @@ fn test_xlsx() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(
+        Type::new(
             MatcherType::DOC,
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             "xlsx",
+            matcher
         ),
         info.get_from_path("testdata/sample.xlsx").unwrap().unwrap()
     );
@@ -43,10 +49,11 @@ fn test_pptx() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(
+        Type::new(
             MatcherType::DOC,
             "application/application/vnd.openxmlformats-officedocument.presentationml.presentation",
             "pptx",
+            matcher
         ),
         info.get_from_path("testdata/sample.pptx").unwrap().unwrap()
     );

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -5,7 +5,7 @@ fn test_doc() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::DOC, "application/msword", "doc",),
+        Type::new_for_test(MatcherType::DOC, "application/msword", "doc"),
         info.get_from_path("testdata/sample.doc").unwrap().unwrap()
     );
 }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -5,7 +5,7 @@ fn test_doc() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::DOC, "application/msword", "doc",),
+        Type::new_for_test(MatcherType::DOC, "application/msword", "doc",),
         info.get_from_path("testdata/sample.doc").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_docx() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(
+        Type::new_for_test(
             MatcherType::DOC,
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "docx",
@@ -29,7 +29,7 @@ fn test_xlsx() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(
+        Type::new_for_test(
             MatcherType::DOC,
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             "xlsx",
@@ -43,7 +43,7 @@ fn test_pptx() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(
+        Type::new_for_test(
             MatcherType::DOC,
             "application/application/vnd.openxmlformats-officedocument.presentationml.presentation",
             "pptx",

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -1,16 +1,11 @@
-extern crate infer;
-
-use infer::Infer;
+use infer::{Infer, MatcherType, Type};
 
 #[test]
 fn test_doc() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/msword"),
-            ext: String::from("doc"),
-        },
+        Type::new(MatcherType::DOC, "application/msword", "doc",),
         info.get_from_path("testdata/sample.doc").unwrap().unwrap()
     );
 }
@@ -20,12 +15,11 @@ fn test_docx() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from(
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ),
-            ext: String::from("docx"),
-        },
+        Type::new(
+            MatcherType::DOC,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "docx",
+        ),
         info.get_from_path("testdata/sample.docx").unwrap().unwrap()
     );
 }
@@ -35,10 +29,11 @@ fn test_xlsx() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
-            ext: String::from("xlsx"),
-        },
+        Type::new(
+            MatcherType::DOC,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "xlsx",
+        ),
         info.get_from_path("testdata/sample.xlsx").unwrap().unwrap()
     );
 }
@@ -48,10 +43,11 @@ fn test_pptx() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/application/vnd.openxmlformats-officedocument.presentationml.presentation"),
-            ext: String::from("pptx"),
-        },
+        Type::new(
+            MatcherType::DOC,
+            "application/application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "pptx",
+        ),
         info.get_from_path("testdata/sample.pptx").unwrap().unwrap()
     );
 }

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -5,7 +5,7 @@ fn test_ttf() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::FONT, "application/font-sfnt", "ttf",),
+        Type::new_for_test(MatcherType::FONT, "application/font-sfnt", "ttf"),
         info.get_from_path("testdata/sample.ttf").unwrap().unwrap()
     );
 }

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -1,11 +1,15 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_ttf() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::FONT, "application/font-sfnt", "ttf"),
+        Type::new(MatcherType::FONT, "application/font-sfnt", "ttf", matcher),
         info.get_from_path("testdata/sample.ttf").unwrap().unwrap()
     );
 }

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -5,7 +5,7 @@ fn test_ttf() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::FONT, "application/font-sfnt", "ttf",),
+        Type::new_for_test(MatcherType::FONT, "application/font-sfnt", "ttf",),
         info.get_from_path("testdata/sample.ttf").unwrap().unwrap()
     );
 }

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -1,16 +1,11 @@
-extern crate infer;
-
-use infer::Infer;
+use infer::{Infer, MatcherType, Type};
 
 #[test]
 fn test_ttf() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("application/font-sfnt"),
-            ext: String::from("ttf"),
-        },
+        Type::new(MatcherType::FONT, "application/font-sfnt", "ttf",),
         info.get_from_path("testdata/sample.ttf").unwrap().unwrap()
     );
 }

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -5,7 +5,7 @@ fn test_jpg() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/jpeg", "jpg",),
+        Type::new_for_test(MatcherType::IMAGE, "image/jpeg", "jpg"),
         info.get_from_path("testdata/sample.jpg").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_png() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/png", "png",),
+        Type::new_for_test(MatcherType::IMAGE, "image/png", "png"),
         info.get_from_path("testdata/sample.png").unwrap().unwrap()
     );
 }
@@ -25,7 +25,7 @@ fn test_gif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/gif", "gif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/gif", "gif"),
         info.get_from_path("testdata/sample.gif").unwrap().unwrap()
     );
 }
@@ -35,7 +35,7 @@ fn test_tif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
         info.get_from_path("testdata/sample.tif").unwrap().unwrap()
     );
 }
@@ -45,7 +45,7 @@ fn test_tif2() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
         info.get_from_path("testdata/sample2.tif").unwrap().unwrap()
     );
 }
@@ -55,7 +55,7 @@ fn test_tif3() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
         info.get_from_path("testdata/sample3.tif").unwrap().unwrap()
     );
 }
@@ -65,7 +65,7 @@ fn test_tif4() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
         info.get_from_path("testdata/sample4.tif").unwrap().unwrap()
     );
 }
@@ -75,7 +75,7 @@ fn test_tif5() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
         info.get_from_path("testdata/sample5.tif").unwrap().unwrap()
     );
 }
@@ -85,7 +85,7 @@ fn test_bmp() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/bmp", "bmp",),
+        Type::new_for_test(MatcherType::IMAGE, "image/bmp", "bmp"),
         info.get_from_path("testdata/sample.bmp").unwrap().unwrap()
     );
 }
@@ -95,7 +95,7 @@ fn test_psd() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/vnd.adobe.photoshop", "psd",),
+        Type::new_for_test(MatcherType::IMAGE, "image/vnd.adobe.photoshop", "psd"),
         info.get_from_path("testdata/sample.psd").unwrap().unwrap()
     );
 }
@@ -105,7 +105,7 @@ fn test_ico() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/vnd.microsoft.icon", "ico",),
+        Type::new_for_test(MatcherType::IMAGE, "image/vnd.microsoft.icon", "ico"),
         info.get_from_path("testdata/sample.ico").unwrap().unwrap()
     );
 }
@@ -115,7 +115,7 @@ fn test_heif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/heif", "heif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/heif", "heif"),
         info.get_from_path("testdata/sample.heic").unwrap().unwrap()
     );
 }
@@ -125,7 +125,7 @@ fn test_avif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/avif", "avif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/avif", "avif"),
         info.get_from_path("testdata/sample.avif").unwrap().unwrap()
     );
 }

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -1,11 +1,15 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_jpg() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/jpeg", "jpg"),
+        Type::new(MatcherType::IMAGE, "image/jpeg", "jpg", matcher),
         info.get_from_path("testdata/sample.jpg").unwrap().unwrap()
     );
 }
@@ -15,7 +19,7 @@ fn test_png() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/png", "png"),
+        Type::new(MatcherType::IMAGE, "image/png", "png", matcher),
         info.get_from_path("testdata/sample.png").unwrap().unwrap()
     );
 }
@@ -25,7 +29,7 @@ fn test_gif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/gif", "gif"),
+        Type::new(MatcherType::IMAGE, "image/gif", "gif", matcher),
         info.get_from_path("testdata/sample.gif").unwrap().unwrap()
     );
 }
@@ -35,7 +39,7 @@ fn test_tif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif", matcher),
         info.get_from_path("testdata/sample.tif").unwrap().unwrap()
     );
 }
@@ -45,7 +49,7 @@ fn test_tif2() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif", matcher),
         info.get_from_path("testdata/sample2.tif").unwrap().unwrap()
     );
 }
@@ -55,7 +59,7 @@ fn test_tif3() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif", matcher),
         info.get_from_path("testdata/sample3.tif").unwrap().unwrap()
     );
 }
@@ -65,7 +69,7 @@ fn test_tif4() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif", matcher),
         info.get_from_path("testdata/sample4.tif").unwrap().unwrap()
     );
 }
@@ -75,7 +79,7 @@ fn test_tif5() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif"),
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif", matcher),
         info.get_from_path("testdata/sample5.tif").unwrap().unwrap()
     );
 }
@@ -85,7 +89,7 @@ fn test_bmp() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/bmp", "bmp"),
+        Type::new(MatcherType::IMAGE, "image/bmp", "bmp", matcher),
         info.get_from_path("testdata/sample.bmp").unwrap().unwrap()
     );
 }
@@ -95,7 +99,12 @@ fn test_psd() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/vnd.adobe.photoshop", "psd"),
+        Type::new(
+            MatcherType::IMAGE,
+            "image/vnd.adobe.photoshop",
+            "psd",
+            matcher
+        ),
         info.get_from_path("testdata/sample.psd").unwrap().unwrap()
     );
 }
@@ -105,7 +114,12 @@ fn test_ico() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/vnd.microsoft.icon", "ico"),
+        Type::new(
+            MatcherType::IMAGE,
+            "image/vnd.microsoft.icon",
+            "ico",
+            matcher
+        ),
         info.get_from_path("testdata/sample.ico").unwrap().unwrap()
     );
 }
@@ -115,7 +129,7 @@ fn test_heif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/heif", "heif"),
+        Type::new(MatcherType::IMAGE, "image/heif", "heif", matcher),
         info.get_from_path("testdata/sample.heic").unwrap().unwrap()
     );
 }
@@ -125,7 +139,7 @@ fn test_avif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::IMAGE, "image/avif", "avif"),
+        Type::new(MatcherType::IMAGE, "image/avif", "avif", matcher),
         info.get_from_path("testdata/sample.avif").unwrap().unwrap()
     );
 }

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -1,16 +1,11 @@
-extern crate infer;
-
-use infer::Infer;
+use infer::{Infer, MatcherType, Type};
 
 #[test]
 fn test_jpg() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/jpeg"),
-            ext: String::from("jpg"),
-        },
+        Type::new(MatcherType::IMAGE, "image/jpeg", "jpg",),
         info.get_from_path("testdata/sample.jpg").unwrap().unwrap()
     );
 }
@@ -20,10 +15,7 @@ fn test_png() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/png"),
-            ext: String::from("png"),
-        },
+        Type::new(MatcherType::IMAGE, "image/png", "png",),
         info.get_from_path("testdata/sample.png").unwrap().unwrap()
     );
 }
@@ -33,10 +25,7 @@ fn test_gif() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/gif"),
-            ext: String::from("gif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/gif", "gif",),
         info.get_from_path("testdata/sample.gif").unwrap().unwrap()
     );
 }
@@ -46,10 +35,7 @@ fn test_tif() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/tiff"),
-            ext: String::from("tif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample.tif").unwrap().unwrap()
     );
 }
@@ -59,10 +45,7 @@ fn test_tif2() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/tiff"),
-            ext: String::from("tif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample2.tif").unwrap().unwrap()
     );
 }
@@ -72,10 +55,7 @@ fn test_tif3() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/tiff"),
-            ext: String::from("tif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample3.tif").unwrap().unwrap()
     );
 }
@@ -85,10 +65,7 @@ fn test_tif4() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/tiff"),
-            ext: String::from("tif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample4.tif").unwrap().unwrap()
     );
 }
@@ -98,10 +75,7 @@ fn test_tif5() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/tiff"),
-            ext: String::from("tif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample5.tif").unwrap().unwrap()
     );
 }
@@ -111,10 +85,7 @@ fn test_bmp() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/bmp"),
-            ext: String::from("bmp"),
-        },
+        Type::new(MatcherType::IMAGE, "image/bmp", "bmp",),
         info.get_from_path("testdata/sample.bmp").unwrap().unwrap()
     );
 }
@@ -124,10 +95,7 @@ fn test_psd() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/vnd.adobe.photoshop"),
-            ext: String::from("psd"),
-        },
+        Type::new(MatcherType::IMAGE, "image/vnd.adobe.photoshop", "psd",),
         info.get_from_path("testdata/sample.psd").unwrap().unwrap()
     );
 }
@@ -137,10 +105,7 @@ fn test_ico() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/vnd.microsoft.icon"),
-            ext: String::from("ico"),
-        },
+        Type::new(MatcherType::IMAGE, "image/vnd.microsoft.icon", "ico",),
         info.get_from_path("testdata/sample.ico").unwrap().unwrap()
     );
 }
@@ -150,10 +115,7 @@ fn test_heif() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/heif"),
-            ext: String::from("heif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/heif", "heif",),
         info.get_from_path("testdata/sample.heic").unwrap().unwrap()
     );
 }
@@ -163,10 +125,7 @@ fn test_avif() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("image/avif"),
-            ext: String::from("avif"),
-        },
+        Type::new(MatcherType::IMAGE, "image/avif", "avif",),
         info.get_from_path("testdata/sample.avif").unwrap().unwrap()
     );
 }

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -5,7 +5,7 @@ fn test_jpg() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/jpeg", "jpg",),
+        Type::new_for_test(MatcherType::IMAGE, "image/jpeg", "jpg",),
         info.get_from_path("testdata/sample.jpg").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_png() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/png", "png",),
+        Type::new_for_test(MatcherType::IMAGE, "image/png", "png",),
         info.get_from_path("testdata/sample.png").unwrap().unwrap()
     );
 }
@@ -25,7 +25,7 @@ fn test_gif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/gif", "gif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/gif", "gif",),
         info.get_from_path("testdata/sample.gif").unwrap().unwrap()
     );
 }
@@ -35,7 +35,7 @@ fn test_tif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample.tif").unwrap().unwrap()
     );
 }
@@ -45,7 +45,7 @@ fn test_tif2() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample2.tif").unwrap().unwrap()
     );
 }
@@ -55,7 +55,7 @@ fn test_tif3() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample3.tif").unwrap().unwrap()
     );
 }
@@ -65,7 +65,7 @@ fn test_tif4() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample4.tif").unwrap().unwrap()
     );
 }
@@ -75,7 +75,7 @@ fn test_tif5() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/tiff", "tif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/tiff", "tif",),
         info.get_from_path("testdata/sample5.tif").unwrap().unwrap()
     );
 }
@@ -85,7 +85,7 @@ fn test_bmp() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/bmp", "bmp",),
+        Type::new_for_test(MatcherType::IMAGE, "image/bmp", "bmp",),
         info.get_from_path("testdata/sample.bmp").unwrap().unwrap()
     );
 }
@@ -95,7 +95,7 @@ fn test_psd() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/vnd.adobe.photoshop", "psd",),
+        Type::new_for_test(MatcherType::IMAGE, "image/vnd.adobe.photoshop", "psd",),
         info.get_from_path("testdata/sample.psd").unwrap().unwrap()
     );
 }
@@ -105,7 +105,7 @@ fn test_ico() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/vnd.microsoft.icon", "ico",),
+        Type::new_for_test(MatcherType::IMAGE, "image/vnd.microsoft.icon", "ico",),
         info.get_from_path("testdata/sample.ico").unwrap().unwrap()
     );
 }
@@ -115,7 +115,7 @@ fn test_heif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/heif", "heif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/heif", "heif",),
         info.get_from_path("testdata/sample.heic").unwrap().unwrap()
     );
 }
@@ -125,7 +125,7 @@ fn test_avif() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::IMAGE, "image/avif", "avif",),
+        Type::new_for_test(MatcherType::IMAGE, "image/avif", "avif",),
         info.get_from_path("testdata/sample.avif").unwrap().unwrap()
     );
 }

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,11 +1,15 @@
 use infer::{Infer, MatcherType, Type};
 
+fn matcher(_buf: &[u8]) -> bool {
+    false
+}
+
 #[test]
 fn test_mp4() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/mp4", "mp4"),
+        Type::new(MatcherType::VIDEO, "video/mp4", "mp4", matcher),
         info.get_from_path("testdata/sample.mp4").unwrap().unwrap()
     );
 }
@@ -15,7 +19,7 @@ fn test_mkv() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/x-matroska", "mkv"),
+        Type::new(MatcherType::VIDEO, "video/x-matroska", "mkv", matcher),
         info.get_from_path("testdata/sample.mkv").unwrap().unwrap()
     );
 }
@@ -25,7 +29,7 @@ fn test_webm() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/webm", "webm"),
+        Type::new(MatcherType::VIDEO, "video/webm", "webm", matcher),
         info.get_from_path("testdata/sample.webm").unwrap().unwrap()
     );
 }
@@ -35,7 +39,7 @@ fn test_mov() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/quicktime", "mov"),
+        Type::new(MatcherType::VIDEO, "video/quicktime", "mov", matcher),
         info.get_from_path("testdata/sample.mov").unwrap().unwrap()
     );
 }
@@ -45,7 +49,7 @@ fn test_avi() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/x-msvideo", "avi"),
+        Type::new(MatcherType::VIDEO, "video/x-msvideo", "avi", matcher),
         info.get_from_path("testdata/sample.avi").unwrap().unwrap()
     );
 }
@@ -55,7 +59,7 @@ fn test_flv() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/x-flv", "flv"),
+        Type::new(MatcherType::VIDEO, "video/x-flv", "flv", matcher),
         info.get_from_path("testdata/sample.flv").unwrap().unwrap()
     );
 }

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,16 +1,11 @@
-extern crate infer;
-
-use infer::Infer;
+use infer::{Infer, MatcherType, Type};
 
 #[test]
 fn test_mp4() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("video/mp4"),
-            ext: String::from("mp4"),
-        },
+        Type::new(MatcherType::VIDEO, "video/mp4", "mp4",),
         info.get_from_path("testdata/sample.mp4").unwrap().unwrap()
     );
 }
@@ -20,10 +15,7 @@ fn test_mkv() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("video/x-matroska"),
-            ext: String::from("mkv"),
-        },
+        Type::new(MatcherType::VIDEO, "video/x-matroska", "mkv",),
         info.get_from_path("testdata/sample.mkv").unwrap().unwrap()
     );
 }
@@ -33,10 +25,7 @@ fn test_webm() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("video/webm"),
-            ext: String::from("webm"),
-        },
+        Type::new(MatcherType::VIDEO, "video/webm", "webm",),
         info.get_from_path("testdata/sample.webm").unwrap().unwrap()
     );
 }
@@ -46,10 +35,7 @@ fn test_mov() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("video/quicktime"),
-            ext: String::from("mov"),
-        },
+        Type::new(MatcherType::VIDEO, "video/quicktime", "mov",),
         info.get_from_path("testdata/sample.mov").unwrap().unwrap()
     );
 }
@@ -59,10 +45,7 @@ fn test_avi() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("video/x-msvideo"),
-            ext: String::from("avi"),
-        },
+        Type::new(MatcherType::VIDEO, "video/x-msvideo", "avi",),
         info.get_from_path("testdata/sample.avi").unwrap().unwrap()
     );
 }
@@ -72,10 +55,7 @@ fn test_flv() {
     let info = Infer::new();
 
     assert_eq!(
-        infer::Type {
-            mime: String::from("video/x-flv"),
-            ext: String::from("flv"),
-        },
+        Type::new(MatcherType::VIDEO, "video/x-flv", "flv",),
         info.get_from_path("testdata/sample.flv").unwrap().unwrap()
     );
 }

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -5,7 +5,7 @@ fn test_mp4() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/mp4", "mp4",),
+        Type::new_for_test(MatcherType::VIDEO, "video/mp4", "mp4"),
         info.get_from_path("testdata/sample.mp4").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_mkv() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/x-matroska", "mkv",),
+        Type::new_for_test(MatcherType::VIDEO, "video/x-matroska", "mkv"),
         info.get_from_path("testdata/sample.mkv").unwrap().unwrap()
     );
 }
@@ -25,7 +25,7 @@ fn test_webm() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/webm", "webm",),
+        Type::new_for_test(MatcherType::VIDEO, "video/webm", "webm"),
         info.get_from_path("testdata/sample.webm").unwrap().unwrap()
     );
 }
@@ -35,7 +35,7 @@ fn test_mov() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/quicktime", "mov",),
+        Type::new_for_test(MatcherType::VIDEO, "video/quicktime", "mov"),
         info.get_from_path("testdata/sample.mov").unwrap().unwrap()
     );
 }
@@ -45,7 +45,7 @@ fn test_avi() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/x-msvideo", "avi",),
+        Type::new_for_test(MatcherType::VIDEO, "video/x-msvideo", "avi"),
         info.get_from_path("testdata/sample.avi").unwrap().unwrap()
     );
 }
@@ -55,7 +55,7 @@ fn test_flv() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new_for_test(MatcherType::VIDEO, "video/x-flv", "flv",),
+        Type::new_for_test(MatcherType::VIDEO, "video/x-flv", "flv"),
         info.get_from_path("testdata/sample.flv").unwrap().unwrap()
     );
 }

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -5,7 +5,7 @@ fn test_mp4() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::VIDEO, "video/mp4", "mp4",),
+        Type::new_for_test(MatcherType::VIDEO, "video/mp4", "mp4",),
         info.get_from_path("testdata/sample.mp4").unwrap().unwrap()
     );
 }
@@ -15,7 +15,7 @@ fn test_mkv() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::VIDEO, "video/x-matroska", "mkv",),
+        Type::new_for_test(MatcherType::VIDEO, "video/x-matroska", "mkv",),
         info.get_from_path("testdata/sample.mkv").unwrap().unwrap()
     );
 }
@@ -25,7 +25,7 @@ fn test_webm() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::VIDEO, "video/webm", "webm",),
+        Type::new_for_test(MatcherType::VIDEO, "video/webm", "webm",),
         info.get_from_path("testdata/sample.webm").unwrap().unwrap()
     );
 }
@@ -35,7 +35,7 @@ fn test_mov() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::VIDEO, "video/quicktime", "mov",),
+        Type::new_for_test(MatcherType::VIDEO, "video/quicktime", "mov",),
         info.get_from_path("testdata/sample.mov").unwrap().unwrap()
     );
 }
@@ -45,7 +45,7 @@ fn test_avi() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::VIDEO, "video/x-msvideo", "avi",),
+        Type::new_for_test(MatcherType::VIDEO, "video/x-msvideo", "avi",),
         info.get_from_path("testdata/sample.avi").unwrap().unwrap()
     );
 }
@@ -55,7 +55,7 @@ fn test_flv() {
     let info = Infer::new();
 
     assert_eq!(
-        Type::new(MatcherType::VIDEO, "video/x-flv", "flv",),
+        Type::new_for_test(MatcherType::VIDEO, "video/x-flv", "flv",),
         info.get_from_path("testdata/sample.flv").unwrap().unwrap()
     );
 }


### PR DESCRIPTION
* refactors infer::Type to avoid continuously going back and forth from String and &str (we need to remove String anyway if we want this crate to be no_std, no_alloc). It also removes the need for a tuple and makes the code much cleaner
* makes the fields of infer::Type private, making it easier to extend it in the future without having to make breaking changes
* removes abbreviations like `ext` and `mime`. I think these were made like so when this was ported from the Go library. Rust doesn't shy away from using full words, for example: ["extension" in the std](https://doc.rust-lang.org/stable/std/path/struct.Path.html#method.extension) and most functions in the [mime_guess crate](https://docs.rs/mime_guess/2.0.3/mime_guess/struct.Mime.html#method.essence_str)
* it also makes iterators easier to read by using them at their fullest, removing the need for the foreach