### PR TITLE
Web types

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -8,6 +8,7 @@ pub enum MatcherType {
     DOC,
     FONT,
     IMAGE,
+    TEXT,
     VIDEO,
     CUSTOM,
 }
@@ -26,7 +27,7 @@ macro_rules! matcher_map {
     };
 }
 
-// Order: Application, Image, Video, Audio, Font, Document, Archive.
+// Order: Application, Image, Video, Audio, Font, Document, Archive, Text.
 // The above order should be preserved when adding new types since
 // it may affect match result and/or performances.
 matcher_map!(
@@ -450,5 +451,12 @@ matcher_map!(
         "application/zstd",
         "zst",
         matchers::archive::is_zst
+    ),
+    // Text
+    (
+        MatcherType::TEXT,
+        "text/html",
+        "html",
+        matchers::text::is_html
     )
 );

--- a/src/map.rs
+++ b/src/map.rs
@@ -458,5 +458,6 @@ matcher_map!(
         "text/html",
         "html",
         matchers::text::is_html
-    )
+    ),
+    (MatcherType::TEXT, "text/xml", "xml", matchers::text::is_xml)
 );

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -4,4 +4,5 @@ pub mod audio;
 pub mod doc;
 pub mod font;
 pub mod image;
+pub mod text;
 pub mod video;

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -1,0 +1,81 @@
+/// Returns whether a buffer is html data.
+///
+/// Conforms to [whatwg](https://mimesniff.spec.whatwg.org/)
+/// specification.
+pub fn is_html(buf: &[u8]) -> bool {
+    let values: &[&[u8]] = &[
+        b"<!DOCTYPE HTML",
+        b"<HTML",
+        b"<HEAD",
+        b"<SCRIPT",
+        b"<IFRAME",
+        b"<H1",
+        b"<DIV",
+        b"<FONT",
+        b"<TABLE",
+        b"<A",
+        b"<STYLE",
+        b"<TITLE",
+        b"<B",
+        b"<BODY",
+        b"<BR",
+        b"<P",
+        b"<!--",
+    ];
+    let buf = trim_start_whitespaces(buf);
+
+    for val in values {
+        if buf.len() <= val.len() {
+            continue;
+        }
+        let b = &buf[..val.len()];
+        if b.eq_ignore_ascii_case(val) {
+            match buf[val.len()] {
+                // tag-terminitating byte
+                0x20 | 0x3E => return true,
+                _ => continue,
+            }
+        }
+    }
+
+    false
+}
+
+/// Strip whitespaces at the beginning of the buffer.
+///
+/// Follows https://mimesniff.spec.whatwg.org
+/// definition of whitespace.
+fn trim_start_whitespaces(buf: &[u8]) -> &[u8] {
+    for (i, b) in buf.iter().enumerate() {
+        match b {
+            0x09 | 0x0A | 0x0C | 0x0D | 0x20 => continue,
+            _ => return &buf[i..],
+        }
+    }
+    &[]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_html, trim_start_whitespaces};
+
+    #[test]
+    fn trim_whitespaces() {
+        let got = trim_start_whitespaces(&[0x09, 0x0A, 0x0C, 0x0D, 0x20, b'A', b'B', b'C']);
+        assert_eq!(got, b"ABC");
+
+        let got = trim_start_whitespaces(b"abc");
+        assert_eq!(got, b"abc");
+
+        let got = trim_start_whitespaces(&[]);
+        assert_eq!(got, &[]);
+    }
+
+    #[test]
+    fn html() {
+        assert_eq!(is_html(b"<"), false);
+        assert_eq!(is_html(b"<HTML"), false);
+        assert_eq!(is_html(b"<HTML "), true);
+        assert_eq!(is_html(b"   <BODY>"), true);
+    }
+}

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -25,11 +25,7 @@ pub fn is_html(buf: &[u8]) -> bool {
     let buf = trim_start_whitespaces(buf);
 
     for val in values {
-        if buf.len() <= val.len() {
-            continue;
-        }
-        let b = &buf[..val.len()];
-        if b.eq_ignore_ascii_case(val) {
+        if starts_with_ignore_ascii_case(buf, val) && buf.len() > val.len() {
             match buf[val.len()] {
                 // tag-terminitating byte
                 0x20 | 0x3E => return true,
@@ -48,11 +44,7 @@ pub fn is_html(buf: &[u8]) -> bool {
 pub fn is_xml(buf: &[u8]) -> bool {
     let val: &[u8] = b"<?xml";
     let buf = trim_start_whitespaces(buf);
-    if buf.len() <= val.len() {
-        return false;
-    }
-    let b = &buf[..val.len()];
-    b.eq_ignore_ascii_case(val)
+    starts_with_ignore_ascii_case(buf, val)
 }
 
 /// Strip whitespaces at the beginning of the buffer.
@@ -67,6 +59,10 @@ fn trim_start_whitespaces(buf: &[u8]) -> &[u8] {
         }
     }
     &[]
+}
+
+fn starts_with_ignore_ascii_case(buf: &[u8], needle: &[u8]) -> bool {
+    buf.len() >= needle.len() && buf[..needle.len()].eq_ignore_ascii_case(needle)
 }
 
 #[cfg(test)]

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -51,14 +51,14 @@ pub fn is_xml(buf: &[u8]) -> bool {
 ///
 /// Follows https://mimesniff.spec.whatwg.org
 /// definition of whitespace.
-fn trim_start_whitespaces(buf: &[u8]) -> &[u8] {
-    for (i, b) in buf.iter().enumerate() {
-        match b {
-            0x09 | 0x0A | 0x0C | 0x0D | 0x20 => continue,
-            _ => return &buf[i..],
+fn trim_start_whitespaces(mut buf: &[u8]) -> &[u8] {
+    while !buf.is_empty() {
+        match buf[0] {
+            0x09 | 0x0A | 0x0C | 0x0D | 0x20 => buf = &buf[1..],
+            _ => break,
         }
     }
-    &[]
+    buf
 }
 
 fn starts_with_ignore_ascii_case(buf: &[u8], needle: &[u8]) -> bool {

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -41,6 +41,20 @@ pub fn is_html(buf: &[u8]) -> bool {
     false
 }
 
+/// Returns whether a buffer is xml data.
+///
+/// Conforms to [whatwg](https://mimesniff.spec.whatwg.org/)
+/// specification.
+pub fn is_xml(buf: &[u8]) -> bool {
+    let val: &[u8] = b"<?xml";
+    let buf = trim_start_whitespaces(buf);
+    if buf.len() <= val.len() {
+        return false;
+    }
+    let b = &buf[..val.len()];
+    b.eq_ignore_ascii_case(val)
+}
+
 /// Strip whitespaces at the beginning of the buffer.
 ///
 /// Follows https://mimesniff.spec.whatwg.org

--- a/testdata/sample.html
+++ b/testdata/sample.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Hello World</title>
+</head>
+
+<body>
+    <p>Hello World!</p>
+</body>
+
+</html>

--- a/testdata/sample.xml
+++ b/testdata/sample.xml
@@ -1,0 +1,5 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+<note>
+  <to>World</to>
+  <body>Hello !</body>
+</note> 

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -9,3 +9,12 @@ test_format!(
     test_html_embed,
     "sample.html"
 );
+
+test_format!(
+    MatcherType::TEXT,
+    "text/xml",
+    "xml",
+    test_xml,
+    test_xml_embed,
+    "sample.xml"
+);

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -1,0 +1,11 @@
+use infer::{MatcherType, Type};
+mod common;
+
+test_format!(
+    MatcherType::TEXT,
+    "text/html",
+    "html",
+    test_html,
+    test_html_embed,
+    "sample.html"
+);


### PR DESCRIPTION
Add some common web types support, using the [whatwg specification](https://mimesniff.spec.whatwg.org/).

Since the algorithm is stripping white spaces I am wondering wether we should limit the buffer size to 256 or 512 bytes (like other implementations do, Go http lib among others) or live this to the responsibility of the caller. Not doing this make this crate vulnerable to DOS attacks with very long space strings. Doing this limits the possibilities for the calling application. Maybe we should leave that to the caller but add a small comment about the danger. Comments welcome.

Cheers