### PR TITLE
Improve tests after the refactor from #18

### DIFF
--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,30 +1,13 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
-test_format!(
-    MatcherType::APP,
-    "application/x-executable",
-    "elf",
-    test_elf,
-    test_elf_embed,
-    "sample_elf"
-);
+test_format!(APP, "application/x-executable", "elf", elf, "sample_elf");
 
 test_format!(
-    MatcherType::APP,
+    APP,
     "application/vnd.microsoft.portable-executable",
     "exe",
-    test_exe,
-    test_exe_embed,
+    exe,
     "sample.exe"
 );
 
-test_format!(
-    MatcherType::APP,
-    "application/wasm",
-    "wasm",
-    test_wasm,
-    test_wasm_embed,
-    "sample.wasm"
-);
+test_format!(APP, "application/wasm", "wasm", wasm, "sample.wasm");

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,21 +1,11 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
 test_format!(
-    MatcherType::ARCHIVE,
+    ARCHIVE,
     "application/vnd.sqlite3",
     "sqlite",
-    test_sqlite,
-    test_sqlite_embed,
+    sqlite,
     "sample.db"
 );
 
-test_format!(
-    MatcherType::ARCHIVE,
-    "application/zstd",
-    "zst",
-    test_zst,
-    test_zst_embed,
-    "sample.tar.zst"
-);
+test_format!(ARCHIVE, "application/zstd", "zst", zst, "sample.tar.zst");

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,12 +1,3 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
-test_format!(
-    MatcherType::AUDIO,
-    "audio/mpeg",
-    "mp3",
-    test_mp3,
-    test_mp3_embed,
-    "sample.mp3"
-);
+test_format!(AUDIO, "audio/mpeg", "mp3", mp3, "sample.mp3");

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,32 +1,34 @@
 #[macro_export]
 macro_rules! test_format {
-    ($exp_matchert:expr, $exp_mimet:expr, $exp_ext:expr, $path_name:ident, $path_embed:ident, $file:expr) => {
-        #[cfg(feature = "std")]
-        #[test]
-        fn $path_name() {
+    ($exp_matchert:ident, $exp_mimet:expr, $exp_ext:expr, $format:ident, $file:expr) => {
+        mod $format {
+            use infer::{MatcherType, Type};
+
             fn matcher(_buf: &[u8]) -> bool {
                 false
             }
 
-            let expected_kind = Type::new($exp_matchert, $exp_mimet, $exp_ext, matcher);
-            let kind = infer::get_from_path(concat!("testdata/", $file))
-                .expect("test file read")
-                .expect("test file matches");
+            #[cfg(feature = "std")]
+            #[test]
+            fn get_from_path() {
+                let expected_kind =
+                    Type::new(MatcherType::$exp_matchert, $exp_mimet, $exp_ext, matcher);
+                let kind = infer::get_from_path(concat!("testdata/", $file))
+                    .expect("test file read")
+                    .expect("test file matches");
 
-            assert_eq!(expected_kind, kind);
-        }
-
-        #[test]
-        fn $path_embed() {
-            fn matcher(_buf: &[u8]) -> bool {
-                false
+                assert_eq!(expected_kind, kind);
             }
 
-            let expected_kind = Type::new($exp_matchert, $exp_mimet, $exp_ext, matcher);
-            let buf = include_bytes!(concat!("../testdata/", $file));
-            let kind = infer::get(buf).expect("test file matches");
+            #[test]
+            fn get() {
+                let expected_kind =
+                    Type::new(MatcherType::$exp_matchert, $exp_mimet, $exp_ext, matcher);
+                let buf = include_bytes!(concat!("../testdata/", $file));
+                let kind = infer::get(buf).expect("test file matches");
 
-            assert_eq!(expected_kind, kind);
+                assert_eq!(expected_kind, kind);
+            }
         }
     };
 }

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -1,39 +1,27 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
-test_format!(
-    MatcherType::DOC,
-    "application/msword",
-    "doc",
-    test_doc,
-    test_doc_embed,
-    "sample.doc"
-);
+test_format!(DOC, "application/msword", "doc", doc, "sample.doc");
 
 test_format!(
-    MatcherType::DOC,
+    DOC,
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "docx",
-    test_docx,
-    test_docx_embed,
+    docx,
     "sample.docx"
 );
 
 test_format!(
-    MatcherType::DOC,
+    DOC,
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "xlsx",
-    test_xlsx,
-    test_xlsx_embed,
+    xlsx,
     "sample.xlsx"
 );
 
 test_format!(
-    MatcherType::DOC,
+    DOC,
     "application/application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "pptx",
-    test_pptx,
-    test_pptx_embed,
+    pptx,
     "sample.pptx"
 );

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -1,12 +1,3 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
-test_format!(
-    MatcherType::FONT,
-    "application/font-sfnt",
-    "ttf",
-    test_ttf,
-    test_ttf_embed,
-    "sample.ttf"
-);
+test_format!(FONT, "application/font-sfnt", "ttf", ttf, "sample.ttf");

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -1,120 +1,27 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/jpeg",
-    "jpg",
-    test_jpg,
-    test_jpg_embed,
-    "sample.jpg"
-);
+test_format!(IMAGE, "image/jpeg", "jpg", jpg, "sample.jpg");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/png",
-    "png",
-    test_png,
-    test_png_embed,
-    "sample.png"
-);
+test_format!(IMAGE, "image/png", "png", png, "sample.png");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/gif",
-    "gif",
-    test_gif,
-    test_gif_embed,
-    "sample.gif"
-);
+test_format!(IMAGE, "image/gif", "gif", gif, "sample.gif");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/tiff",
-    "tif",
-    test_tif,
-    test_tif_embed,
-    "sample.tif"
-);
+test_format!(IMAGE, "image/tiff", "tif", tif, "sample.tif");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/tiff",
-    "tif",
-    test_tif2,
-    test_tif2_embed,
-    "sample2.tif"
-);
+test_format!(IMAGE, "image/tiff", "tif", tif2, "sample2.tif");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/tiff",
-    "tif",
-    test_tif3,
-    test_tif3_embed,
-    "sample3.tif"
-);
+test_format!(IMAGE, "image/tiff", "tif", tif3, "sample3.tif");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/tiff",
-    "tif",
-    test_tif4,
-    test_tif4_embed,
-    "sample4.tif"
-);
+test_format!(IMAGE, "image/tiff", "tif", tif4, "sample4.tif");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/tiff",
-    "tif",
-    test_tif5,
-    test_tif5_embed,
-    "sample5.tif"
-);
+test_format!(IMAGE, "image/tiff", "tif", tif5, "sample5.tif");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/bmp",
-    "bmp",
-    test_bmp,
-    test_bmp_embed,
-    "sample.bmp"
-);
+test_format!(IMAGE, "image/bmp", "bmp", bmp, "sample.bmp");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/vnd.adobe.photoshop",
-    "psd",
-    test_psd,
-    test_psd_embed,
-    "sample.psd"
-);
+test_format!(IMAGE, "image/vnd.adobe.photoshop", "psd", psd, "sample.psd");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/vnd.microsoft.icon",
-    "ico",
-    test_ico,
-    test_ico_embed,
-    "sample.ico"
-);
+test_format!(IMAGE, "image/vnd.microsoft.icon", "ico", ico, "sample.ico");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/heif",
-    "heif",
-    test_heif,
-    test_heif_embed,
-    "sample.heic"
-);
+test_format!(IMAGE, "image/heif", "heif", heif, "sample.heic");
 
-test_format!(
-    MatcherType::IMAGE,
-    "image/avif",
-    "avif",
-    test_avif,
-    test_avif_embed,
-    "sample.avif"
-);
+test_format!(IMAGE, "image/avif", "avif", avif, "sample.avif");

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -1,20 +1,5 @@
-use infer::{MatcherType, Type};
 mod common;
 
-test_format!(
-    MatcherType::TEXT,
-    "text/html",
-    "html",
-    test_html,
-    test_html_embed,
-    "sample.html"
-);
+test_format!(TEXT, "text/html", "html", html, "sample.html");
 
-test_format!(
-    MatcherType::TEXT,
-    "text/xml",
-    "xml",
-    test_xml,
-    test_xml_embed,
-    "sample.xml"
-);
+test_format!(TEXT, "text/xml", "xml", xml, "sample.xml");

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,57 +1,13 @@
-use infer::{MatcherType, Type};
-
 mod common;
 
-test_format!(
-    MatcherType::VIDEO,
-    "video/mp4",
-    "mp4",
-    test_mp4,
-    test_mp4_embed,
-    "sample.mp4"
-);
+test_format!(VIDEO, "video/mp4", "mp4", mp4, "sample.mp4");
 
-test_format!(
-    MatcherType::VIDEO,
-    "video/x-matroska",
-    "mkv",
-    test_mkv,
-    test_mkv_embed,
-    "sample.mkv"
-);
+test_format!(VIDEO, "video/x-matroska", "mkv", mkv, "sample.mkv");
 
-test_format!(
-    MatcherType::VIDEO,
-    "video/webm",
-    "webm",
-    test_webm,
-    test_webm_embed,
-    "sample.webm"
-);
+test_format!(VIDEO, "video/webm", "webm", webm, "sample.webm");
 
-test_format!(
-    MatcherType::VIDEO,
-    "video/quicktime",
-    "mov",
-    test_mov,
-    test_mov_embed,
-    "sample.mov"
-);
+test_format!(VIDEO, "video/quicktime", "mov", mov, "sample.mov");
 
-test_format!(
-    MatcherType::VIDEO,
-    "video/x-msvideo",
-    "avi",
-    test_avi,
-    test_avi_embed,
-    "sample.avi"
-);
+test_format!(VIDEO, "video/x-msvideo", "avi", avi, "sample.avi");
 
-test_format!(
-    MatcherType::VIDEO,
-    "video/x-flv",
-    "flv",
-    test_flv,
-    test_flv_embed,
-    "sample.flv"
-);
+test_format!(VIDEO, "video/x-flv", "flv", flv, "sample.flv");


### PR DESCRIPTION
I think I found a solution for https://github.com/bojand/infer/pull/18#discussion_r456563915 by making every sample test it's own module. This makes the `test_format` macro much cleaner and writing new tests much simpler.