### PR TITLE
Release 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infer"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Bojan <dbojan@gmail.com>"]
 edition = "2018"
 description = "Small crate to infer file types based on its magic number signature"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add it to your `Cargo.toml` like so:
 
 ```toml
 [dependencies]
-infer = "0.2"
+infer = "0.3"
 ```
 
 If you are not using the custom matcher or the file type from file path functionality you
@@ -34,7 +34,7 @@ can make this crate even lighter by importing it with no default features, like 
 
 ```toml
 [dependencies]
-infer = { version = "0.2", default-features = false }
+infer = { version = "0.3", default-features = false }
 ```
 
 ## no_std and no_alloc support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ assert_eq!(kind.extension(), "foo");
 ```
 */
 #![crate_name = "infer"]
+#![doc(html_root_url = "https://docs.rs/infer/0.3.0")]
+#![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,26 +236,6 @@ impl Infer {
         Ok(self.get(&bytes))
     }
 
-    /// Returns the `Type` from a mime string.
-    ///
-    /// See [`get_from_str`](./fn.get_from_str.html).
-    pub fn get_from_str<S: AsRef<str>>(&self, val: S) -> Option<Type> {
-        let val = val.as_ref();
-        self.iter_matchers()
-            .find(|kind| kind.mime_type() == val)
-            .copied()
-    }
-
-    /// Returns the `Type` from a file extension.
-    ///
-    /// See [`get_from_ext`](./fn.get_from_ext.html).
-    pub fn get_from_ext<S: AsRef<str>>(&self, val: S) -> Option<Type> {
-        let val = val.as_ref();
-        self.iter_matchers()
-            .find(|kind| kind.extension() == val)
-            .copied()
-    }
-
     /// Determines whether a buffer is of given extension.
     ///
     /// # Examples
@@ -459,32 +439,6 @@ pub fn get(buf: &[u8]) -> Option<Type> {
 #[cfg(feature = "std")]
 pub fn get_from_path<P: AsRef<Path>>(path: P) -> io::Result<Option<Type>> {
     INFER.get_from_path(path)
-}
-
-/// Returns the `Type` from a mime string.
-///
-/// # Examples
-///
-/// ```rust
-/// let kind = infer::get_from_str("video/mp4").expect("mime type is known");
-/// assert_eq!(kind.mime_type(), "video/mp4");
-/// assert_eq!(kind.extension(), "mp4");
-/// ```
-pub fn get_from_str<S: AsRef<str>>(val: S) -> Option<Type> {
-    INFER.get_from_str(val)
-}
-
-/// Returns the `Type` from a file extension.
-///
-/// # Examples
-///
-/// ```rust
-/// let kind = infer::get_from_ext("jpg").expect("extension is known");
-/// assert_eq!(kind.mime_type(), "image/jpeg");
-/// assert_eq!(kind.extension(), "jpg");
-/// ```
-pub fn get_from_ext<S: AsRef<str>>(val: S) -> Option<Type> {
-    INFER.get_from_ext(val)
 }
 
 /// Determines whether a buffer is of given extension.


### PR DESCRIPTION
I've lost interest in working in an integration between `infer` and `mime-db` or `mime_guess`, so I think it makes sense to release this as is now and leave the rest of the work for a future version.

@ririsoft I'm reverting #16, since we decided not to have it unless we fully supported all extensions.