### PR TITLE
Fix clippy::upper_case_acronyms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ impl Infer {
     ///
     /// See [`is_app`](./fn.is_app.html).
     pub fn is_app(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::APP)
+        self.is_type(buf, MatcherType::App)
     }
 
     /// Determines whether a buffer is an archive type.
@@ -293,7 +293,7 @@ impl Infer {
     ///
     /// See [`is_archive`](./fn.is_archive.html).
     pub fn is_archive(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::ARCHIVE)
+        self.is_type(buf, MatcherType::Archive)
     }
 
     /// Determines whether a buffer is an audio type.
@@ -302,7 +302,7 @@ impl Infer {
     ///
     /// See [`is_audio`](./fn.is_audio.html).
     pub fn is_audio(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::AUDIO)
+        self.is_type(buf, MatcherType::Audio)
     }
 
     /// Determines whether a buffer is a book type.
@@ -311,7 +311,7 @@ impl Infer {
     ///
     /// See [`is_book`](./fn.is_book.html).
     pub fn is_book(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::BOOK)
+        self.is_type(buf, MatcherType::Book)
     }
 
     /// Determines whether a buffer is a document type.
@@ -320,7 +320,7 @@ impl Infer {
     ///
     /// See [`is_document`](./fn.is_document.html).
     pub fn is_document(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::DOC)
+        self.is_type(buf, MatcherType::Doc)
     }
 
     /// Determines whether a buffer is a font type.
@@ -329,7 +329,7 @@ impl Infer {
     ///
     /// See [`is_font`](./fn.is_font.html).
     pub fn is_font(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::FONT)
+        self.is_type(buf, MatcherType::Font)
     }
 
     /// Determines whether a buffer is an image type.
@@ -338,7 +338,7 @@ impl Infer {
     ///
     /// See [`is_image`](./fn.is_image.html).
     pub fn is_image(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::IMAGE)
+        self.is_type(buf, MatcherType::Image)
     }
 
     /// Determines whether a buffer is a video type.
@@ -347,7 +347,7 @@ impl Infer {
     ///
     /// See [`is_video`](./fn.is_video.html).
     pub fn is_video(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::VIDEO)
+        self.is_type(buf, MatcherType::Video)
     }
 
     /// Determines whether a buffer is one of the custom types added.
@@ -368,7 +368,7 @@ impl Infer {
     /// # }
     /// ```
     pub fn is_custom(&self, buf: &[u8]) -> bool {
-        self.is_type(buf, MatcherType::CUSTOM)
+        self.is_type(buf, MatcherType::Custom)
     }
 
     /// Adds a custom matcher.
@@ -394,7 +394,7 @@ impl Infer {
     #[cfg(feature = "alloc")]
     pub fn add(&mut self, mime_type: &'static str, extension: &'static str, m: Matcher) {
         self.mmap.push(Type::new_static(
-            MatcherType::CUSTOM,
+            MatcherType::Custom,
             mime_type,
             extension,
             WrapMatcher(m),

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,18 +1,17 @@
 use super::{matchers, Matcher, Type};
 
-#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MatcherType {
-    APP,
-    ARCHIVE,
-    AUDIO,
-    BOOK,
-    DOC,
-    FONT,
-    IMAGE,
-    TEXT,
-    VIDEO,
-    CUSTOM,
+    App,
+    Archive,
+    Audio,
+    Book,
+    Doc,
+    Font,
+    Image,
+    Text,
+    Video,
+    Custom,
 }
 
 // This is needed until function pointers can be used in `const fn`.
@@ -35,490 +34,490 @@ macro_rules! matcher_map {
 matcher_map!(
     // Application
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/wasm",
         "wasm",
         matchers::app::is_wasm
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/x-executable",
         "elf",
         matchers::app::is_elf
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/vnd.microsoft.portable-executable",
         "exe",
         matchers::app::is_exe
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/vnd.microsoft.portable-executable",
         "dll",
         matchers::app::is_dll
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/java",
         "class",
         matchers::app::is_java
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/x-llvm",
         "bc",
         matchers::app::is_llvm
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/x-mach-binary",
         "mach",
         matchers::app::is_mach
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/vnd.android.dex",
         "dex",
         matchers::app::is_dex
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/vnd.android.dey",
         "dey",
         matchers::app::is_dey
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/x-x509-ca-cert",
         "der",
         matchers::app::is_der
     ),
     (
-        MatcherType::APP,
+        MatcherType::App,
         "application/x-executable",
         "obj",
         matchers::app::is_coff
     ),
     // Book
     (
-        MatcherType::BOOK,
+        MatcherType::Book,
         "application/epub+zip",
         "epub",
         matchers::book::is_epub
     ),
     (
-        MatcherType::BOOK,
+        MatcherType::Book,
         "application/x-mobipocket-ebook",
         "mobi",
         matchers::book::is_mobi
     ),
     // Image
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/jpeg",
         "jpg",
         matchers::image::is_jpeg
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/jp2",
         "jp2",
         matchers::image::is_jpeg2000
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/png",
         "png",
         matchers::image::is_png
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/gif",
         "gif",
         matchers::image::is_gif
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/webp",
         "webp",
         matchers::image::is_webp
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/x-canon-cr2",
         "cr2",
         matchers::image::is_cr2
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/tiff",
         "tif",
         matchers::image::is_tiff
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/bmp",
         "bmp",
         matchers::image::is_bmp
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/vnd.ms-photo",
         "jxr",
         matchers::image::is_jxr
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/vnd.adobe.photoshop",
         "psd",
         matchers::image::is_psd
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/vnd.microsoft.icon",
         "ico",
         matchers::image::is_ico
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/heif",
         "heif",
         matchers::image::is_heif
     ),
     (
-        MatcherType::IMAGE,
+        MatcherType::Image,
         "image/avif",
         "avif",
         matchers::image::is_avif
     ),
     // Video
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/mp4",
         "mp4",
         matchers::video::is_mp4
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/x-m4v",
         "m4v",
         matchers::video::is_m4v
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/x-matroska",
         "mkv",
         matchers::video::is_mkv
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/webm",
         "webm",
         matchers::video::is_webm
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/quicktime",
         "mov",
         matchers::video::is_mov
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/x-msvideo",
         "avi",
         matchers::video::is_avi
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/x-ms-wmv",
         "wmv",
         matchers::video::is_wmv
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/mpeg",
         "mpg",
         matchers::video::is_mpeg
     ),
     (
-        MatcherType::VIDEO,
+        MatcherType::Video,
         "video/x-flv",
         "flv",
         matchers::video::is_flv
     ),
     // Audio
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/midi",
         "midi",
         matchers::audio::is_midi
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/mpeg",
         "mp3",
         matchers::audio::is_mp3
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/m4a",
         "m4a",
         matchers::audio::is_m4a
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/ogg",
         "ogg",
         matchers::audio::is_ogg
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/x-flac",
         "flac",
         matchers::audio::is_flac
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/x-wav",
         "wav",
         matchers::audio::is_wav
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/amr",
         "amr",
         matchers::audio::is_amr
     ),
     (
-        MatcherType::AUDIO,
+        MatcherType::Audio,
         "audio/aac",
         "aac",
         matchers::audio::is_aac
     ),
     // Font
     (
-        MatcherType::FONT,
+        MatcherType::Font,
         "application/font-woff",
         "woff",
         matchers::font::is_woff
     ),
     (
-        MatcherType::FONT,
+        MatcherType::Font,
         "application/font-woff",
         "woff2",
         matchers::font::is_woff2
     ),
     (
-        MatcherType::FONT,
+        MatcherType::Font,
         "application/font-sfnt",
         "ttf",
         matchers::font::is_ttf
     ),
     (
-        MatcherType::FONT,
+        MatcherType::Font,
         "application/font-sfnt",
         "otf",
         matchers::font::is_otf
     ),
     // Document
     (
-        MatcherType::DOC,
+        MatcherType::Doc,
         "application/msword",
         "doc",
         matchers::doc::is_doc
     ),
     (
-        MatcherType::DOC,
+        MatcherType::Doc,
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "docx",
         matchers::doc::is_docx
     ),
     (
-        MatcherType::DOC,
+        MatcherType::Doc,
         "application/vnd.ms-excel",
         "xls",
         matchers::doc::is_xls
     ),
     (
-        MatcherType::DOC,
+        MatcherType::Doc,
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "xlsx",
         matchers::doc::is_xlsx
     ),
     (
-        MatcherType::DOC,
+        MatcherType::Doc,
         "application/vnd.ms-powerpoint",
         "ppt",
         matchers::doc::is_ppt
     ),
     (
-        MatcherType::DOC,
+        MatcherType::Doc,
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         "pptx",
         matchers::doc::is_pptx
     ),
     // Archive
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/epub+zip",
         "epub",
         matchers::archive::is_epub
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/zip",
         "zip",
         matchers::archive::is_zip
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-tar",
         "tar",
         matchers::archive::is_tar
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/vnd.rar",
         "rar",
         matchers::archive::is_rar
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/gzip",
         "gz",
         matchers::archive::is_gz
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-bzip2",
         "bz2",
         matchers::archive::is_bz2
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-7z-compressed",
         "7z",
         matchers::archive::is_7z
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-xz",
         "xz",
         matchers::archive::is_xz
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/pdf",
         "pdf",
         matchers::archive::is_pdf
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-shockwave-flash",
         "swf",
         matchers::archive::is_swf
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/rtf",
         "rtf",
         matchers::archive::is_rtf
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/octet-stream",
         "eot",
         matchers::archive::is_eot
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/postscript",
         "ps",
         matchers::archive::is_ps
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/vnd.sqlite3",
         "sqlite",
         matchers::archive::is_sqlite
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-nintendo-nes-rom",
         "nes",
         matchers::archive::is_nes
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-google-chrome-extension",
         "crx",
         matchers::archive::is_crx
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/vnd.ms-cab-compressed",
         "cab",
         matchers::archive::is_cab
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/vnd.debian.binary-package",
         "deb",
         matchers::archive::is_deb
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-unix-archive",
         "ar",
         matchers::archive::is_ar
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-compress",
         "Z",
         matchers::archive::is_z
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-lzip",
         "lz",
         matchers::archive::is_lz
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-rpm",
         "rpm",
         matchers::archive::is_rpm
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/dicom",
         "dcm",
         matchers::archive::is_dcm
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/zstd",
         "zst",
         matchers::archive::is_zst
     ),
     (
-        MatcherType::ARCHIVE,
+        MatcherType::Archive,
         "application/x-ole-storage",
         "msi",
         matchers::archive::is_msi
     ),
     // Text
     (
-        MatcherType::TEXT,
+        MatcherType::Text,
         "text/html",
         "html",
         matchers::text::is_html
     ),
-    (MatcherType::TEXT, "text/xml", "xml", matchers::text::is_xml),
+    (MatcherType::Text, "text/xml", "xml", matchers::text::is_xml),
     (
-        MatcherType::TEXT,
+        MatcherType::Text,
         "text/x-shellscript",
         "sh",
         matchers::text::is_shellscript

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,9 +1,9 @@
 mod common;
 
-test_format!(APP, "application/x-executable", "elf", elf, "sample_elf");
+test_format!(App, "application/x-executable", "elf", elf, "sample_elf");
 
 test_format!(
-    APP,
+    App,
     "application/vnd.microsoft.portable-executable",
     "exe",
     exe,
@@ -11,7 +11,7 @@ test_format!(
 );
 
 test_format!(
-    APP,
+    App,
     "application/x-mach-binary",
     "mach",
     mach_x86,
@@ -19,7 +19,7 @@ test_format!(
 );
 
 test_format!(
-    APP,
+    App,
     "application/x-mach-binary",
     "mach",
     mach_x64,
@@ -27,7 +27,7 @@ test_format!(
 );
 
 test_format!(
-    APP,
+    App,
     "application/x-mach-binary",
     "mach",
     mach_ppc,
@@ -35,13 +35,13 @@ test_format!(
 );
 
 test_format!(
-    APP,
+    App,
     "application/x-mach-binary",
     "mach",
     mach_fat,
     "sample_mach_fat"
 );
 
-test_format!(APP, "application/wasm", "wasm", wasm, "sample.wasm");
+test_format!(App, "application/wasm", "wasm", wasm, "sample.wasm");
 
-test_format!(APP, "application/x-x509-ca-cert", "der", der, "sample.der");
+test_format!(App, "application/x-x509-ca-cert", "der", der, "sample.der");

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,11 +1,11 @@
 mod common;
 
 test_format!(
-    ARCHIVE,
+    Archive,
     "application/vnd.sqlite3",
     "sqlite",
     sqlite,
     "sample.db"
 );
 
-test_format!(ARCHIVE, "application/zstd", "zst", zst, "sample.tar.zst");
+test_format!(Archive, "application/zstd", "zst", zst, "sample.tar.zst");

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,3 +1,3 @@
 mod common;
 
-test_format!(AUDIO, "audio/mpeg", "mp3", mp3, "sample.mp3");
+test_format!(Audio, "audio/mpeg", "mp3", mp3, "sample.mp3");

--- a/tests/book.rs
+++ b/tests/book.rs
@@ -1,8 +1,8 @@
 mod common;
 
-test_format!(BOOK, "application/epub+zip", "epub", epub, "sample.epub");
+test_format!(Book, "application/epub+zip", "epub", epub, "sample.epub");
 test_format!(
-    BOOK,
+    Book,
     "application/x-mobipocket-ebook",
     "mobi",
     mobi,

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -24,10 +24,10 @@ macro_rules! test_format_get_only {
 }
 
 #[cfg(feature = "std")]
-test_format_get_only!(DOC, "application/msword", "doc", doc, "sample.doc");
+test_format_get_only!(Doc, "application/msword", "doc", doc, "sample.doc");
 
 test_format!(
-    DOC,
+    Doc,
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "docx",
     docx,
@@ -35,10 +35,10 @@ test_format!(
 );
 
 #[cfg(feature = "std")]
-test_format_get_only!(DOC, "application/vnd.ms-excel", "xls", xls, "sample.xls");
+test_format_get_only!(Doc, "application/vnd.ms-excel", "xls", xls, "sample.xls");
 
 test_format!(
-    DOC,
+    Doc,
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "xlsx",
     xlsx,
@@ -47,7 +47,7 @@ test_format!(
 
 #[cfg(feature = "std")]
 test_format_get_only!(
-    DOC,
+    Doc,
     "application/vnd.ms-powerpoint",
     "ppt",
     ppt,
@@ -55,7 +55,7 @@ test_format_get_only!(
 );
 
 test_format!(
-    DOC,
+    Doc,
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "pptx",
     pptx,

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -1,3 +1,3 @@
 mod common;
 
-test_format!(FONT, "application/font-sfnt", "ttf", ttf, "sample.ttf");
+test_format!(Font, "application/font-sfnt", "ttf", ttf, "sample.ttf");

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -1,27 +1,27 @@
 mod common;
 
-test_format!(IMAGE, "image/jpeg", "jpg", jpg, "sample.jpg");
+test_format!(Image, "image/jpeg", "jpg", jpg, "sample.jpg");
 
-test_format!(IMAGE, "image/png", "png", png, "sample.png");
+test_format!(Image, "image/png", "png", png, "sample.png");
 
-test_format!(IMAGE, "image/gif", "gif", gif, "sample.gif");
+test_format!(Image, "image/gif", "gif", gif, "sample.gif");
 
-test_format!(IMAGE, "image/tiff", "tif", tif, "sample.tif");
+test_format!(Image, "image/tiff", "tif", tif, "sample.tif");
 
-test_format!(IMAGE, "image/tiff", "tif", tif2, "sample2.tif");
+test_format!(Image, "image/tiff", "tif", tif2, "sample2.tif");
 
-test_format!(IMAGE, "image/tiff", "tif", tif3, "sample3.tif");
+test_format!(Image, "image/tiff", "tif", tif3, "sample3.tif");
 
-test_format!(IMAGE, "image/tiff", "tif", tif4, "sample4.tif");
+test_format!(Image, "image/tiff", "tif", tif4, "sample4.tif");
 
-test_format!(IMAGE, "image/tiff", "tif", tif5, "sample5.tif");
+test_format!(Image, "image/tiff", "tif", tif5, "sample5.tif");
 
-test_format!(IMAGE, "image/bmp", "bmp", bmp, "sample.bmp");
+test_format!(Image, "image/bmp", "bmp", bmp, "sample.bmp");
 
-test_format!(IMAGE, "image/vnd.adobe.photoshop", "psd", psd, "sample.psd");
+test_format!(Image, "image/vnd.adobe.photoshop", "psd", psd, "sample.psd");
 
-test_format!(IMAGE, "image/vnd.microsoft.icon", "ico", ico, "sample.ico");
+test_format!(Image, "image/vnd.microsoft.icon", "ico", ico, "sample.ico");
 
-test_format!(IMAGE, "image/heif", "heif", heif, "sample.heic");
+test_format!(Image, "image/heif", "heif", heif, "sample.heic");
 
-test_format!(IMAGE, "image/avif", "avif", avif, "sample.avif");
+test_format!(Image, "image/avif", "avif", avif, "sample.avif");

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -1,7 +1,7 @@
 mod common;
 
-test_format!(TEXT, "text/html", "html", html, "sample.html");
+test_format!(Text, "text/html", "html", html, "sample.html");
 
-test_format!(TEXT, "text/xml", "xml", xml, "sample.xml");
+test_format!(Text, "text/xml", "xml", xml, "sample.xml");
 
-test_format!(TEXT, "text/x-shellscript", "sh", sh, "sample.sh");
+test_format!(Text, "text/x-shellscript", "sh", sh, "sample.sh");

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,13 +1,13 @@
 mod common;
 
-test_format!(VIDEO, "video/mp4", "mp4", mp4, "sample.mp4");
+test_format!(Video, "video/mp4", "mp4", mp4, "sample.mp4");
 
-test_format!(VIDEO, "video/x-matroska", "mkv", mkv, "sample.mkv");
+test_format!(Video, "video/x-matroska", "mkv", mkv, "sample.mkv");
 
-test_format!(VIDEO, "video/webm", "webm", webm, "sample.webm");
+test_format!(Video, "video/webm", "webm", webm, "sample.webm");
 
-test_format!(VIDEO, "video/quicktime", "mov", mov, "sample.mov");
+test_format!(Video, "video/quicktime", "mov", mov, "sample.mov");
 
-test_format!(VIDEO, "video/x-msvideo", "avi", avi, "sample.avi");
+test_format!(Video, "video/x-msvideo", "avi", avi, "sample.avi");
 
-test_format!(VIDEO, "video/x-flv", "flv", flv, "sample.flv");
+test_format!(Video, "video/x-flv", "flv", flv, "sample.flv");


### PR DESCRIPTION
This change should have gone in with the 0.4 release, since `MatcherType` doesn't respect naming conventions

https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms