### PR TITLE
Exclude tests and testdata from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 homepage = "https://github.com/bojand/infer"
 repository = "https://github.com/bojand/infer"
 documentation = "https://docs.rs/infer"
+exclude = ["/testdata", "/tests"]
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Reduces size of crate from 8975KB to 17KB
crates.io limits crates to 10MB max

https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields