### PR TITLE
feat: add get_from_file method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,19 @@ impl Infer {
         Ok(self.get(&bytes))
     }
 
+    /// Returns the file type of the file
+    #[cfg(feature = "std")]
+    pub fn get_from_file(&self, file: &File) -> io::Result<Option<Type>> {
+        let limit = file
+            .metadata()
+            .map(|m| std::cmp::min(m.len(), 8192) as usize + 1)
+            .unwrap_or(0);
+        let mut bytes = Vec::with_capacity(limit);
+        file.take(8192).read_to_end(&mut bytes)?;
+
+        Ok(self.get(&bytes))
+    }
+
     /// Determines whether a buffer is of given extension.
     ///
     /// # Examples


### PR DESCRIPTION
This is `get_from_path` supplement . some time we want to get file type , the file is opend. so I add this method, It can get type by opend file.