### PR TITLE
Add support for text/plain

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ assert_eq!(kind.extension(), "foo");
 - **der** - `application/x-x509-ca-cert`
 - **obj** - `application/x-executable`
 
+#### Text
+
+- **html** - `text/html`
+- **xml** - `text/xml`
+- **sh** - `text/x-shellscript`
+- **txt** - `text/plain`
+
 ## Known Issues
 
 - `exe` and `dll` have the same magic number so it's not possible to tell which one just based on the binary data. `exe` is returned for all.

--- a/src/map.rs
+++ b/src/map.rs
@@ -558,5 +558,11 @@ matcher_map!(
         "text/x-shellscript",
         "sh",
         matchers::text::is_shellscript
+    ),
+    (
+        MatcherType::Text,
+        "text/plain",
+        "txt",
+        matchers::text::is_text_plain
     )
 );

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -70,9 +70,15 @@ pub fn is_shellscript(buf: &[u8]) -> bool {
     buf.len() > 2 && &buf[..2] == b"#!"
 }
 
+/// True when the buffer is readable characters.
+pub fn is_text_plain(buf: &[u8]) -> bool {
+    !buf.is_empty() &&
+        buf.iter().all(|&byte| byte > 0x1f || byte == 0x09 || byte == 0x0a || byte == 0x0d)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{is_html, is_shellscript, trim_start_whitespaces};
+    use super::{is_html, is_shellscript, trim_start_whitespaces, is_text_plain};
 
     #[test]
     fn trim_whitespaces() {
@@ -97,5 +103,15 @@ mod tests {
     #[test]
     fn shellscript() {
         assert!(!is_shellscript(b"#!"));
+    }
+
+    #[test]
+    fn plain_text() {
+        assert!(is_text_plain(b"hello, world"));
+        assert!(is_text_plain(b"\xF0\x9F\x92\xA9")); // poop emoji
+        assert!(is_text_plain(b"\xE3\x81\x93")); // Japanese letter
+        assert!(is_text_plain(b"hello\tworld\nhow\r\nare you?"));
+        assert!(!is_text_plain(b"\x08")); // backspace
+        assert!(!is_text_plain(b"OK\x08")); // backspace
     }
 }


### PR DESCRIPTION
This adds detection for the `text/plain` MIME type, with a file
extension of `txt`.

Detecting plain text is tricky, and it isn't very clearly spelled out in
any of the relevant RFCs (822, 2045, 2046). The best I can figure is "no
control characters" (00-1F), but even that isn't quite right: tab,
newline, and carriage return are control characters that often occur in
plain text.

---

While here, update the README with the list of all the `text` media
types.