### PR TITLE
fix matcher for woff & woff2

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -338,6 +338,12 @@ matcher_map!(
         "otf",
         matchers::font::is_otf
     ),
+    (
+        MatcherType::Font,
+        "application/font-collection",
+        "ttc",
+        matchers::font::is_ttc
+    ),
     // Document
     (
         MatcherType::Doc,

--- a/src/matchers/font.rs
+++ b/src/matchers/font.rs
@@ -1,19 +1,11 @@
 /// Returns whether a buffer is WOFF font data.
 pub fn is_woff(buf: &[u8]) -> bool {
-    buf.len() > 3
-        && buf[0] == 0x77
-        && buf[1] == 0x4F
-        && buf[2] == 0x46
-        && buf[3] == 0x46
+    buf.len() > 3 && buf[0] == 0x77 && buf[1] == 0x4F && buf[2] == 0x46 && buf[3] == 0x46
 }
 
 /// Returns whether a buffer is WOFF2 font data.
 pub fn is_woff2(buf: &[u8]) -> bool {
-    buf.len() > 3
-        && buf[0] == 0x77
-        && buf[1] == 0x4F
-        && buf[2] == 0x46
-        && buf[3] == 0x32
+    buf.len() > 3 && buf[0] == 0x77 && buf[1] == 0x4F && buf[2] == 0x46 && buf[3] == 0x32
 }
 
 /// Returns whether a buffer is TTF font data.
@@ -34,4 +26,9 @@ pub fn is_otf(buf: &[u8]) -> bool {
         && buf[2] == 0x54
         && buf[3] == 0x4F
         && buf[4] == 0x00
+}
+
+/// Returns whether a buffer is TTC font data.
+pub fn is_ttc(buf: &[u8]) -> bool {
+    buf.len() > 3 && buf[0] == 0x74 && buf[1] == 0x74 && buf[2] == 0x63 && buf[3] == 0x66
 }

--- a/src/matchers/font.rs
+++ b/src/matchers/font.rs
@@ -1,27 +1,19 @@
 /// Returns whether a buffer is WOFF font data.
 pub fn is_woff(buf: &[u8]) -> bool {
-    buf.len() > 7
+    buf.len() > 3
         && buf[0] == 0x77
         && buf[1] == 0x4F
         && buf[2] == 0x46
         && buf[3] == 0x46
-        && buf[4] == 0x00
-        && buf[5] == 0x01
-        && buf[6] == 0x00
-        && buf[7] == 0x00
 }
 
 /// Returns whether a buffer is WOFF2 font data.
 pub fn is_woff2(buf: &[u8]) -> bool {
-    buf.len() > 7
+    buf.len() > 3
         && buf[0] == 0x77
         && buf[1] == 0x4F
         && buf[2] == 0x46
         && buf[3] == 0x32
-        && buf[4] == 0x00
-        && buf[5] == 0x01
-        && buf[6] == 0x00
-        && buf[7] == 0x00
 }
 
 /// Returns whether a buffer is TTF font data.


### PR DESCRIPTION
This allows more woff/woff2 file to be recognized. fixes #67 