### PR TITLE
Add support for XLSX files generated by Apache POI and Numbers

### DIFF
--- a/src/matchers/doc.rs
+++ b/src/matchers/doc.rs
@@ -84,10 +84,16 @@ fn msooxml(buf: &[u8]) -> Option<DocType> {
     // file we have.  Correct the mimetype with the registered ones:
     // http://technet.microsoft.com/en-us/library/cc179224.aspx
     start_offset += idx + 4 + 26;
-    check_msooml(buf, start_offset)?;
 
     // OpenOffice/Libreoffice orders ZIP entry differently, so check the 4th file
     start_offset += 26;
+    let idx = search(buf, start_offset, 6000);
+    match idx {
+        Some(idx) => start_offset += idx + 4 + 26,
+        None => return Some(DocType::OOXML),
+    };
+
+    // Check the 5th file, for Numbers and Apache POI sources
     let idx = search(buf, start_offset, 6000);
     match idx {
         Some(idx) => start_offset += idx + 4 + 26,


### PR DESCRIPTION
## Fix: Incorrect Detection of certain `xlsx` Files in `infer::get()`

When using `infer::get()`, I encountered an issue where some `xlsx` files were incorrectly detected as `zip` files. This inconsistency seemed to depend on the source of the `xlsx` file.

Upon reviewing the code for inferring msooxml files, I found that `xlsx` files generated by Numbers and Apache POI have the `xlb` bytes in a different position compared to those from other applications. To ensure correct detection, it was necessary to skip over and check the following PK Header as well.

This PR adds a check for the 5th PK Header, allowing proper detection of `xlsx` files from these sources.