### PR TITLE
Fix: support ID3V1 tagged mp3 files properly

### DIFF
--- a/src/matchers/audio.rs
+++ b/src/matchers/audio.rs
@@ -8,7 +8,10 @@ pub fn is_mp3(buf: &[u8]) -> bool {
     buf.len() > 2
         && ((buf[0] == 0x49 && buf[1] == 0x44 && buf[2] == 0x33) // ID3v2
 			// Final bit (has crc32) may be or may not be set.
-			|| (buf[0] == 0xFF && buf[1] == 0xFB))
+	    		// ID3V1 Support
+			|| (buf[0] == 0xFF && buf[1] == 0xFB)
+	   		|| (buf[0] == 0xFF && buf[1] == 0xF3)
+	   		|| (buf[0] == 0xFF && buf[1] == 0xF2))
 }
 
 /// Returns whether a buffer is M4A data.


### PR DESCRIPTION
Added: ID3V1 support

For some reason only 0xFF 0xFB was supported, while https://en.wikipedia.org/wiki/List_of_file_signatures also lists 0xFF 0xF2 and 0xFF 0xF3