### PR TITLE
match SVG

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -221,6 +221,12 @@ matcher_map!(
         "djvu",
         matchers::image::is_djvu
     ),
+    (
+        MatcherType::Image,
+        "image/svg+xml",
+        "svg",
+        matchers::image::is_svg
+    ),
     // Video
     (
         MatcherType::Video,

--- a/src/matchers/image.rs
+++ b/src/matchers/image.rs
@@ -210,6 +210,11 @@ pub fn is_djvu(buf: &[u8]) -> bool {
         && buf[14] == 0x56
 }
 
+/// Returns whether a buffer is SVG image data.
+pub fn is_svg(buf: &[u8]) -> bool {
+    buf.len() >= 4 && &buf[..4] == b"<svg"
+}
+
 // GetFtyp returns the major brand, minor version and compatible brands of the ISO-BMFF data
 fn get_ftyp(buf: &[u8]) -> Option<(&[u8], &[u8], impl Iterator<Item = &[u8]>)> {
     if buf.len() < 16 {


### PR DESCRIPTION
This is not a very robust SVG match: it relies on the content starting with exactly "<svg". Still, it is better than nothing, I think.