### PR TITLE
Fix Clippy pedantic + Add miri

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,29 @@
+name: Miri
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  miri:
+    name: Run Miri
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Setup Miri
+        run: cargo miri setup
+
+      - name: Run Miri tests
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation
+        run: cargo miri test
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infer"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Bojan <dbojan@gmail.com>"]
 edition = "2021"
 description = "Small crate to infer file type based on magic number signatures"
@@ -23,4 +23,4 @@ path = "examples/file.rs"
 required-features = ["std"]
 
 [dependencies]
-cfb = { version = "0.7.0", optional = true }
+cfb = { version = "0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "infer"
 version = "0.21.0"
 authors = ["Bojan <dbojan@gmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "Small crate to infer file type based on magic number signatures"
 license = "MIT"
 keywords = ["magic-number", "filetype", "mime", "mime-types", "no_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "infer"
 version = "0.20.0"
 authors = ["Bojan <dbojan@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Small crate to infer file type based on magic number signatures"
 license = "MIT"
 keywords = ["magic-number", "filetype", "mime", "mime-types", "no_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ path = "examples/file.rs"
 required-features = ["std"]
 
 [dependencies]
-cfb = { version = "0", optional = true }
+cfb = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "infer"
 version = "0.21.0"
 authors = ["Bojan <dbojan@gmail.com>"]
-edition = "2024"
+edition = "2021"
 description = "Small crate to infer file type based on magic number signatures"
 license = "MIT"
 keywords = ["magic-number", "filetype", "mime", "mime-types", "no_std"]

--- a/examples/file.rs
+++ b/examples/file.rs
@@ -3,12 +3,9 @@ use std::process::exit;
 
 fn main() {
     let mut args = args();
-    let path = match args.nth(1) {
-        Some(path) => path,
-        None => {
-            eprintln!("Please specify the file path");
-            exit(1);
-        }
+    let Some(path) = args.nth(1) else {
+        eprintln!("Please specify the file path");
+        exit(1);
     };
 
     match infer::get_from_path(path) {
@@ -24,7 +21,7 @@ fn main() {
         }
         Err(e) => {
             eprintln!("Looks like something went wrong 😔");
-            eprintln!("{}", e);
+            eprintln!("{e}");
             exit(1);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::struct_field_names)]
 /*!
 Small crate to infer file and MIME type by checking the
 [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)) signature.
@@ -70,6 +69,7 @@ assert_eq!(kind.extension(), "foo");
 #![crate_name = "infer"]
 #![doc(html_root_url = "https://docs.rs/infer/latest")]
 #![forbid(unsafe_code)]
+#![allow(clippy::struct_field_names)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]

--- a/src/matchers/app.rs
+++ b/src/matchers/app.rs
@@ -6,6 +6,7 @@
 /// use std::fs;
 /// assert!(infer::app::is_wasm(&fs::read("testdata/sample.wasm").unwrap()));
 /// ```
+#[must_use]
 pub fn is_wasm(buf: &[u8]) -> bool {
     // WASM has starts with `\0asm`, followed by the version.
     // http://webassembly.github.io/spec/core/binary/modules.html#binary-magic
@@ -28,21 +29,25 @@ pub fn is_wasm(buf: &[u8]) -> bool {
 /// use std::fs;
 /// assert!(infer::app::is_exe(&fs::read("testdata/sample.exe").unwrap()));
 /// ```
+#[must_use]
 pub fn is_exe(buf: &[u8]) -> bool {
     buf.len() > 1 && buf[0] == 0x4D && buf[1] == 0x5A
 }
 
 /// Returns whether a buffer is a DLL. DLL and EXE have the same magic number, so returns true also for an EXE.
+#[must_use]
 pub fn is_dll(buf: &[u8]) -> bool {
     is_exe(buf)
 }
 
 /// Returns whether a buffer is an ELF.
+#[must_use]
 pub fn is_elf(buf: &[u8]) -> bool {
     buf.len() > 52 && buf[0] == 0x7F && buf[1] == 0x45 && buf[2] == 0x4C && buf[3] == 0x46
 }
 
 /// Returns whether a buffer is compiled Java bytecode.
+#[must_use]
 pub fn is_java(buf: &[u8]) -> bool {
     if buf.len() < 8 || [0xca, 0xfe, 0xba, 0xbe] != buf[0..4] {
         return false;
@@ -64,11 +69,13 @@ pub fn is_java(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is LLVM Bitcode.
+#[must_use]
 pub fn is_llvm(buf: &[u8]) -> bool {
     buf.len() >= 2 && buf[0] == 0x42 && buf[1] == 0x43
 }
 
 /// Returns whether a buffer is a Mach-O binary.
+#[must_use]
 pub fn is_mach(buf: &[u8]) -> bool {
     // Mach-O binaries can be one of four variants: x86, x64, PowerPC, "Fat" (x86 + PowerPC)
     // https://ilostmynotes.blogspot.com/2014/05/mach-o-filetype-identification.html
@@ -91,6 +98,7 @@ pub fn is_mach(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a Dalvik Executable (DEX).
+#[must_use]
 pub fn is_dex(buf: &[u8]) -> bool {
     // https://source.android.com/devices/tech/dalvik/dex-format#dex-file-magic
 
@@ -102,6 +110,7 @@ pub fn is_dex(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a Dey Optimized Dalvik Executable (ODEX).
+#[must_use]
 pub fn is_dey(buf: &[u8]) -> bool {
     buf.len() > 100
     // magic
@@ -111,6 +120,7 @@ pub fn is_dey(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer DER encoded X.509 certificate.
+#[must_use]
 pub fn is_der(buf: &[u8]) -> bool {
     // https://en.wikipedia.org/wiki/List_of_file_signatures
     // https://github.com/ReFirmLabs/binwalk/blob/master/src/binwalk/magic/crypto#L25-L37
@@ -122,26 +132,31 @@ pub fn is_der(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a Common Object File Format for i386 architecture.
+#[must_use]
 pub fn is_coff_i386(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x4C && buf[1] == 0x01
 }
 
 /// Returns whether a buffer is a Common Object File Format for x64 architecture.
+#[must_use]
 pub fn is_coff_x64(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x64 && buf[1] == 0x86
 }
 
 /// Returns whether a buffer is a Common Object File Format for Itanium architecture.
+#[must_use]
 pub fn is_coff_ia64(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x00 && buf[1] == 0x02
 }
 
 /// Returns whether a buffer is a Common Object File Format.
+#[must_use]
 pub fn is_coff(buf: &[u8]) -> bool {
     is_coff_x64(buf) || is_coff_i386(buf) || is_coff_ia64(buf)
 }
 
 /// Returns whether a buffer is pem
+#[must_use]
 pub fn is_pem(buf: &[u8]) -> bool {
     // https://en.wikipedia.org/wiki/List_of_file_signatures
     buf.len() > 11
@@ -159,6 +174,7 @@ pub fn is_pem(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a QCOW2 disk.
+#[must_use]
 pub fn is_qcow2(buf: &[u8]) -> bool {
     // https://github.com/qemu/qemu/blob/master/docs/interop/qcow2.txt
     buf.len() > 4 && buf[0] == b'Q' && buf[1] == b'F' && buf[2] == b'I' && buf[3] == 0xFB

--- a/src/matchers/archive.rs
+++ b/src/matchers/archive.rs
@@ -297,11 +297,6 @@ pub fn is_zst(buf: &[u8]) -> bool {
 // LZ4 compressed data is made of one or more frames.
 // There are two frame formats defined by LZ4: LZ4 Frame format and Skippable frames.
 // See more details from https://github.com/lz4/lz4/blob/v1.9.4/doc/lz4_Frame_format.md
-/// # Panics
-///
-/// let magic = `u32::from_le_bytes(buf`[0..4].`try_into().unwrap()`);
-/// Cannot panic because buf[0..4] is guaranteed to be 4 bytes long
-/// by the preceding check of `buf.len()` < 8
 #[must_use]
 pub fn is_lz4(buf: &[u8]) -> bool {
     // LZ4 frame magic

--- a/src/matchers/archive.rs
+++ b/src/matchers/archive.rs
@@ -256,6 +256,11 @@ const ZSTD_SKIP_MASK: usize = 0xFFFF_FFF0;
 // Zstandard compressed data is made of one or more frames.
 // There are two frame formats defined by Zstandard: Zstandard frames and Skippable frames.
 // See more details from https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2
+/// # Panics
+///
+/// let magic = `u32::from_le_bytes(buf`[0..4].`try_into().unwrap()`);
+/// Cannot panic because buf[0..4] is guaranteed to be 4 bytes long
+/// by the preceding check of `buf.len()` < 8
 #[must_use]
 pub fn is_zst(buf: &[u8]) -> bool {
     if buf.len() > 3 && buf[0] == 0x28 && buf[1] == 0xB5 && buf[2] == 0x2F && buf[3] == 0xFD {
@@ -292,6 +297,11 @@ pub fn is_zst(buf: &[u8]) -> bool {
 // LZ4 compressed data is made of one or more frames.
 // There are two frame formats defined by LZ4: LZ4 Frame format and Skippable frames.
 // See more details from https://github.com/lz4/lz4/blob/v1.9.4/doc/lz4_Frame_format.md
+/// # Panics
+///
+/// let magic = `u32::from_le_bytes(buf`[0..4].`try_into().unwrap()`);
+/// Cannot panic because buf[0..4] is guaranteed to be 4 bytes long
+/// by the preceding check of `buf.len()` < 8
 #[must_use]
 pub fn is_lz4(buf: &[u8]) -> bool {
     // LZ4 frame magic

--- a/src/matchers/archive.rs
+++ b/src/matchers/archive.rs
@@ -266,10 +266,7 @@ pub fn is_zst(buf: &[u8]) -> bool {
         return false;
     }
 
-    let Ok(magic_bytes) = buf[0..4].try_into() else {
-        return false;
-    };
-    let magic = u32::from_le_bytes(magic_bytes);
+    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
     let Ok(magic) = usize::try_from(magic) else {
         return false;
     };
@@ -278,10 +275,7 @@ pub fn is_zst(buf: &[u8]) -> bool {
         return false;
     }
 
-    let Ok(len_bytes) = buf[4..8].try_into() else {
-        return false;
-    };
-    let data_len = u32::from_le_bytes(len_bytes);
+    let data_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
     let Ok(data_len) = usize::try_from(data_len) else {
         return false;
     };
@@ -309,10 +303,7 @@ pub fn is_lz4(buf: &[u8]) -> bool {
         return false;
     }
 
-    let Ok(magic_bytes) = buf[0..4].try_into() else {
-        return false;
-    };
-    let magic = u32::from_le_bytes(magic_bytes);
+    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
     let Ok(magic) = usize::try_from(magic) else {
         return false;
     };
@@ -321,10 +312,7 @@ pub fn is_lz4(buf: &[u8]) -> bool {
         return false;
     }
 
-    let Ok(len_bytes) = buf[4..8].try_into() else {
-        return false;
-    };
-    let data_len = u32::from_le_bytes(len_bytes);
+    let data_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
     let Ok(data_len) = usize::try_from(data_len) else {
         return false;
     };

--- a/src/matchers/archive.rs
+++ b/src/matchers/archive.rs
@@ -1,11 +1,13 @@
 use core::convert::{TryFrom, TryInto};
 
 /// Returns whether a buffer is an ePub.
+#[must_use]
 pub fn is_epub(buf: &[u8]) -> bool {
     crate::book::is_epub(buf)
 }
 
 /// Returns whether a buffer is a zip archive.
+#[must_use]
 pub fn is_zip(buf: &[u8]) -> bool {
     buf.len() > 3
         && buf[0] == 0x50
@@ -26,6 +28,7 @@ pub fn is_zip(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a tar archive.
+#[must_use]
 pub fn is_tar(buf: &[u8]) -> bool {
     buf.len() > 261
         && buf[257] == 0x75
@@ -35,6 +38,8 @@ pub fn is_tar(buf: &[u8]) -> bool {
         && buf[261] == 0x72
 }
 
+/// Returns whether a buffer is a PAR2 archive.
+#[must_use]
 pub fn is_par2(buf: &[u8]) -> bool {
     buf.len() > 8
         && buf[0] == 0x50
@@ -48,6 +53,7 @@ pub fn is_par2(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a RAR archive.
+#[must_use]
 pub fn is_rar(buf: &[u8]) -> bool {
     buf.len() > 6
         && buf[0] == 0x52
@@ -60,16 +66,19 @@ pub fn is_rar(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a gzip archive.
+#[must_use]
 pub fn is_gz(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x1F && buf[1] == 0x8B && buf[2] == 0x8
 }
 
 /// Returns whether a buffer is a bzip2 archive.
+#[must_use]
 pub fn is_bz2(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x42 && buf[1] == 0x5A && buf[2] == 0x68
 }
 
 /// Returns whether a buffer is a bzip3 archive.
+#[must_use]
 pub fn is_bz3(buf: &[u8]) -> bool {
     buf.len() > 4
         && buf[0] == b'B'
@@ -80,6 +89,7 @@ pub fn is_bz3(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a 7z archive.
+#[must_use]
 pub fn is_7z(buf: &[u8]) -> bool {
     buf.len() > 5
         && buf[0] == 0x37
@@ -91,16 +101,19 @@ pub fn is_7z(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a PDF.
+#[must_use]
 pub fn is_pdf(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x25 && buf[1] == 0x50 && buf[2] == 0x44 && buf[3] == 0x46
 }
 
 /// Returns whether a buffer is a SWF.
+#[must_use]
 pub fn is_swf(buf: &[u8]) -> bool {
     buf.len() > 2 && (buf[0] == 0x43 || buf[0] == 0x46) && buf[1] == 0x57 && buf[2] == 0x53
 }
 
 /// Returns whether a buffer is an RTF.
+#[must_use]
 pub fn is_rtf(buf: &[u8]) -> bool {
     buf.len() > 4
         && buf[0] == 0x7B
@@ -111,16 +124,19 @@ pub fn is_rtf(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a Nintendo NES ROM.
+#[must_use]
 pub fn is_nes(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x4E && buf[1] == 0x45 && buf[2] == 0x53 && buf[3] == 0x1A
 }
 
 /// Returns whether a buffer is Google Chrome Extension
+#[must_use]
 pub fn is_crx(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x43 && buf[1] == 0x72 && buf[2] == 0x32 && buf[3] == 0x34
 }
 
 /// Returns whether a buffer is a CAB.
+#[must_use]
 pub fn is_cab(buf: &[u8]) -> bool {
     buf.len() > 3
         && ((buf[0] == 0x4D && buf[1] == 0x53 && buf[2] == 0x43 && buf[3] == 0x46)
@@ -128,6 +144,7 @@ pub fn is_cab(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a eot octet stream.
+#[must_use]
 pub fn is_eot(buf: &[u8]) -> bool {
     buf.len() > 35
         && buf[34] == 0x4C
@@ -138,11 +155,13 @@ pub fn is_eot(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is postscript.
+#[must_use]
 pub fn is_ps(buf: &[u8]) -> bool {
     buf.len() > 1 && buf[0] == 0x25 && buf[1] == 0x21
 }
 
 /// Returns whether a buffer is xz archive.
+#[must_use]
 pub fn is_xz(buf: &[u8]) -> bool {
     buf.len() > 5
         && buf[0] == 0xFD
@@ -161,11 +180,13 @@ pub fn is_xz(buf: &[u8]) -> bool {
 /// use std::fs;
 /// assert!(infer::archive::is_sqlite(&fs::read("testdata/sample.db").unwrap()));
 /// ```
+#[must_use]
 pub fn is_sqlite(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x53 && buf[1] == 0x51 && buf[2] == 0x4C && buf[3] == 0x69
 }
 
 /// Returns whether a buffer is a deb archive.
+#[must_use]
 pub fn is_deb(buf: &[u8]) -> bool {
     buf.len() > 20
         && buf[0] == 0x21
@@ -192,6 +213,7 @@ pub fn is_deb(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a ar archive.
+#[must_use]
 pub fn is_ar(buf: &[u8]) -> bool {
     buf.len() > 6
         && buf[0] == 0x21
@@ -204,32 +226,37 @@ pub fn is_ar(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a z archive.
+#[must_use]
 pub fn is_z(buf: &[u8]) -> bool {
     buf.len() > 1 && buf[0] == 0x1F && (buf[1] == 0xA0 || buf[1] == 0x9D)
 }
 
 /// Returns whether a buffer is a lzip archive.
+#[must_use]
 pub fn is_lz(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x4C && buf[1] == 0x5A && buf[2] == 0x49 && buf[3] == 0x50
 }
 
 /// Returns whether a buffer is an RPM.
+#[must_use]
 pub fn is_rpm(buf: &[u8]) -> bool {
     buf.len() > 96 && buf[0] == 0xED && buf[1] == 0xAB && buf[2] == 0xEE && buf[3] == 0xDB
 }
 
 /// Returns whether a buffer is a dcm archive.
+#[must_use]
 pub fn is_dcm(buf: &[u8]) -> bool {
     buf.len() > 131 && buf[128] == 0x44 && buf[129] == 0x49 && buf[130] == 0x43 && buf[131] == 0x4D
 }
 
-const ZSTD_SKIP_START: usize = 0x184D2A50;
-const ZSTD_SKIP_MASK: usize = 0xFFFFFFF0;
+const ZSTD_SKIP_START: usize = 0x184D_2A50;
+const ZSTD_SKIP_MASK: usize = 0xFFFF_FFF0;
 
 /// Returns whether a buffer is a Zstd archive.
 // Zstandard compressed data is made of one or more frames.
 // There are two frame formats defined by Zstandard: Zstandard frames and Skippable frames.
 // See more details from https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2
+#[must_use]
 pub fn is_zst(buf: &[u8]) -> bool {
     if buf.len() > 3 && buf[0] == 0x28 && buf[1] == 0xB5 && buf[2] == 0x2F && buf[3] == 0xFD {
         return true;
@@ -239,7 +266,10 @@ pub fn is_zst(buf: &[u8]) -> bool {
         return false;
     }
 
-    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+    let Ok(magic_bytes) = buf[0..4].try_into() else {
+        return false;
+    };
+    let magic = u32::from_le_bytes(magic_bytes);
     let Ok(magic) = usize::try_from(magic) else {
         return false;
     };
@@ -248,7 +278,10 @@ pub fn is_zst(buf: &[u8]) -> bool {
         return false;
     }
 
-    let data_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
+    let Ok(len_bytes) = buf[4..8].try_into() else {
+        return false;
+    };
+    let data_len = u32::from_le_bytes(len_bytes);
     let Ok(data_len) = usize::try_from(data_len) else {
         return false;
     };
@@ -265,7 +298,9 @@ pub fn is_zst(buf: &[u8]) -> bool {
 // LZ4 compressed data is made of one or more frames.
 // There are two frame formats defined by LZ4: LZ4 Frame format and Skippable frames.
 // See more details from https://github.com/lz4/lz4/blob/v1.9.4/doc/lz4_Frame_format.md
+#[must_use]
 pub fn is_lz4(buf: &[u8]) -> bool {
+    // LZ4 frame magic
     if buf.len() > 3 && buf[0] == 0x04 && buf[1] == 0x22 && buf[2] == 0x4D && buf[3] == 0x18 {
         return true;
     }
@@ -274,7 +309,10 @@ pub fn is_lz4(buf: &[u8]) -> bool {
         return false;
     }
 
-    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+    let Ok(magic_bytes) = buf[0..4].try_into() else {
+        return false;
+    };
+    let magic = u32::from_le_bytes(magic_bytes);
     let Ok(magic) = usize::try_from(magic) else {
         return false;
     };
@@ -283,7 +321,10 @@ pub fn is_lz4(buf: &[u8]) -> bool {
         return false;
     }
 
-    let data_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
+    let Ok(len_bytes) = buf[4..8].try_into() else {
+        return false;
+    };
+    let data_len = u32::from_le_bytes(len_bytes);
     let Ok(data_len) = usize::try_from(data_len) else {
         return false;
     };
@@ -297,6 +338,7 @@ pub fn is_lz4(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a MSI Windows Installer archive.
+#[must_use]
 pub fn is_msi(buf: &[u8]) -> bool {
     buf.len() > 7
         && buf[0] == 0xD0
@@ -310,6 +352,7 @@ pub fn is_msi(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a CPIO archive.
+#[must_use]
 pub fn is_cpio(buf: &[u8]) -> bool {
     (buf.len() > 1
         && ((buf[0] == 0xC7 && buf[1] == 0x71) // little endian, old format

--- a/src/matchers/audio.rs
+++ b/src/matchers/audio.rs
@@ -1,9 +1,11 @@
-/// Returns whether a buffer is MIDI data.
+/// Returns whether a buffer is MIDI data.*
+#[must_use]
 pub fn is_midi(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x4D && buf[1] == 0x54 && buf[2] == 0x68 && buf[3] == 0x64
 }
 
 /// Returns whether a buffer is MP3 data.
+#[must_use]
 pub fn is_mp3(buf: &[u8]) -> bool {
     buf.len() > 2
         && ((buf[0] == 0x49 && buf[1] == 0x44 && buf[2] == 0x33) // ID3v2
@@ -12,6 +14,7 @@ pub fn is_mp3(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is M4A data.
+#[must_use]
 pub fn is_m4a(buf: &[u8]) -> bool {
     buf.len() > 10
         && ((buf[4] == 0x66
@@ -25,11 +28,13 @@ pub fn is_m4a(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is OGG data.
+#[must_use]
 pub fn is_ogg(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x4F && buf[1] == 0x67 && buf[2] == 0x67 && buf[3] == 0x53
 }
 
 /// Returns whether a buffer is OGG Opus data.
+#[must_use]
 pub fn is_ogg_opus(buf: &[u8]) -> bool {
     if !is_ogg(buf) {
         return false;
@@ -47,11 +52,13 @@ pub fn is_ogg_opus(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is FLAC data.
+#[must_use]
 pub fn is_flac(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x66 && buf[1] == 0x4C && buf[2] == 0x61 && buf[3] == 0x43
 }
 
 /// Returns whether a buffer is WAV data.
+#[must_use]
 pub fn is_wav(buf: &[u8]) -> bool {
     buf.len() > 11
         && buf[0] == 0x52
@@ -65,6 +72,7 @@ pub fn is_wav(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is AMR data.
+#[must_use]
 pub fn is_amr(buf: &[u8]) -> bool {
     buf.len() > 11
         && buf[0] == 0x23
@@ -76,11 +84,13 @@ pub fn is_amr(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is AAC data.
+#[must_use]
 pub fn is_aac(buf: &[u8]) -> bool {
     buf.len() > 1 && buf[0] == 0xFF && (buf[1] == 0xF1 || buf[1] == 0xF9)
 }
 
 /// Returns whether a buffer is AIFF data.
+#[must_use]
 pub fn is_aiff(buf: &[u8]) -> bool {
     buf.len() > 11
         && buf[0] == 0x46
@@ -94,12 +104,14 @@ pub fn is_aiff(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is DSF data.
+#[must_use]
 pub fn is_dsf(buf: &[u8]) -> bool {
     // ref: https://dsd-guide.com/sites/default/files/white-papers/DSFFileFormatSpec_E.pdf
     buf.len() > 4 && buf[0] == b'D' && buf[1] == b'S' && buf[2] == b'D' && buf[3] == b' '
 }
 
 /// Returns whether a buffer is APE (Monkey's Audio) data.
+#[must_use]
 pub fn is_ape(buf: &[u8]) -> bool {
     // ref: https://github.com/fernandotcl/monkeys-audio/blob/master/src/MACLib/APEHeader.h
     buf.len() > 4 && buf[0] == b'M' && buf[1] == b'A' && buf[2] == b'C' && buf[3] == b' '

--- a/src/matchers/audio.rs
+++ b/src/matchers/audio.rs
@@ -1,4 +1,4 @@
-/// Returns whether a buffer is MIDI data.*
+/// Returns whether a buffer is MIDI data.
 #[must_use]
 pub fn is_midi(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x4D && buf[1] == 0x54 && buf[2] == 0x68 && buf[3] == 0x64

--- a/src/matchers/book.rs
+++ b/src/matchers/book.rs
@@ -1,4 +1,5 @@
 /// Returns whether a buffer is an ePub.
+#[must_use]
 pub fn is_epub(buf: &[u8]) -> bool {
     buf.len() > 57
         && buf[0] == 0x50
@@ -36,6 +37,7 @@ pub fn is_epub(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a mobi.
+#[must_use]
 pub fn is_mobi(buf: &[u8]) -> bool {
     buf.len() > 67
         // BOOK

--- a/src/matchers/doc.rs
+++ b/src/matchers/doc.rs
@@ -38,7 +38,7 @@ pub fn is_xlsx(buf: &[u8]) -> bool {
     msooxml(buf) == Some(DocType::XLSX)
 }
 
-/// Returns whether a buffer is Microsoft `PowerPoint` 97-2003 Presentation (PPT) data.
+/// Returns whether a buffer is Microsoft PowerPoint 97-2003 Presentation (PPT) data.
 #[must_use]
 pub fn is_ppt(buf: &[u8]) -> bool {
     ole2(buf) == Some(DocType::PPT)

--- a/src/matchers/doc.rs
+++ b/src/matchers/doc.rs
@@ -15,31 +15,37 @@ enum DocType {
 }
 
 /// Returns whether a buffer is Microsoft Word Document (DOC) data.
+#[must_use]
 pub fn is_doc(buf: &[u8]) -> bool {
     ole2(buf) == Some(DocType::DOC)
 }
 
 /// Returns whether a buffer is Microsoft Word Open XML Format Document (DOCX) data.
+#[must_use]
 pub fn is_docx(buf: &[u8]) -> bool {
     msooxml(buf) == Some(DocType::DOCX)
 }
 
 /// Returns whether a buffer is Microsoft Excel 97-2003 Worksheet (XLS) data.
+#[must_use]
 pub fn is_xls(buf: &[u8]) -> bool {
     ole2(buf) == Some(DocType::XLS)
 }
 
 /// Returns whether a buffer is Microsoft Excel Open XML Format Spreadsheet (XLSX) data.
+#[must_use]
 pub fn is_xlsx(buf: &[u8]) -> bool {
     msooxml(buf) == Some(DocType::XLSX)
 }
 
-/// Returns whether a buffer is Microsoft PowerPoint 97-2003 Presentation (PPT) data.
+/// Returns whether a buffer is Microsoft `PowerPoint` 97-2003 Presentation (PPT) data.
+#[must_use]
 pub fn is_ppt(buf: &[u8]) -> bool {
     ole2(buf) == Some(DocType::PPT)
 }
 
-/// Returns whether a buffer is Microsoft PowerPoint Open XML Presentation (PPTX) data.
+/// Returns whether a buffer is Microsoft `PowerPoint` Open XML Presentation (PPTX) data.
+#[must_use]
 pub fn is_pptx(buf: &[u8]) -> bool {
     msooxml(buf) == Some(DocType::PPTX)
 }
@@ -92,7 +98,7 @@ fn msooxml(buf: &[u8]) -> Option<DocType> {
     match idx {
         Some(idx) => start_offset += idx + 4 + 26,
         None => return Some(DocType::OOXML),
-    };
+    }
 
     let typo = check_msooml(buf, start_offset);
     if typo.is_some() {

--- a/src/matchers/font.rs
+++ b/src/matchers/font.rs
@@ -1,4 +1,5 @@
 /// Returns whether a buffer is WOFF font data.
+#[must_use]
 pub fn is_woff(buf: &[u8]) -> bool {
     buf.len() > 7
         && buf[0] == 0x77
@@ -12,6 +13,7 @@ pub fn is_woff(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is WOFF2 font data.
+#[must_use]
 pub fn is_woff2(buf: &[u8]) -> bool {
     buf.len() > 7
         && buf[0] == 0x77
@@ -25,6 +27,7 @@ pub fn is_woff2(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is TTF font data.
+#[must_use]
 pub fn is_ttf(buf: &[u8]) -> bool {
     buf.len() > 4
         && buf[0] == 0x00
@@ -35,6 +38,7 @@ pub fn is_ttf(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is OTF font data.
+#[must_use]
 pub fn is_otf(buf: &[u8]) -> bool {
     buf.len() > 4
         && buf[0] == 0x4F

--- a/src/matchers/image.rs
+++ b/src/matchers/image.rs
@@ -1,11 +1,13 @@
 use core::convert::TryInto;
 
 /// Returns whether a buffer is JPEG image data.
+#[must_use]
 pub fn is_jpeg(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0xFF && buf[1] == 0xD8 && buf[2] == 0xFF
 }
 
 /// Returns whether a buffer is jpg2 image data.
+#[must_use]
 pub fn is_jpeg2000(buf: &[u8]) -> bool {
     buf.len() > 12
         && buf[0] == 0x0
@@ -24,21 +26,25 @@ pub fn is_jpeg2000(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is PNG image data.
+#[must_use]
 pub fn is_png(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x89 && buf[1] == 0x50 && buf[2] == 0x4E && buf[3] == 0x47
 }
 
 /// Returns whether a buffer is GIF image data.
+#[must_use]
 pub fn is_gif(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x47 && buf[1] == 0x49 && buf[2] == 0x46
 }
 
 /// Returns whether a buffer is WEBP image data.
+#[must_use]
 pub fn is_webp(buf: &[u8]) -> bool {
     buf.len() > 11 && buf[8] == 0x57 && buf[9] == 0x45 && buf[10] == 0x42 && buf[11] == 0x50
 }
 
 /// Returns whether a buffer is Canon CR2 image data.
+#[must_use]
 pub fn is_cr2(buf: &[u8]) -> bool {
     buf.len() > 10
         && ((buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0)
@@ -49,6 +55,7 @@ pub fn is_cr2(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is TIFF image data.
+#[must_use]
 pub fn is_tiff(buf: &[u8]) -> bool {
     buf.len() > 9
         && ((buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0)
@@ -59,26 +66,31 @@ pub fn is_tiff(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is BMP image data.
+#[must_use]
 pub fn is_bmp(buf: &[u8]) -> bool {
     buf.len() > 1 && buf[0] == 0x42 && buf[1] == 0x4D
 }
 
 /// Returns whether a buffer is jxr image data.
+#[must_use]
 pub fn is_jxr(buf: &[u8]) -> bool {
     buf.len() > 2 && buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0xBC
 }
 
 /// Returns whether a buffer is Photoshop PSD image data.
+#[must_use]
 pub fn is_psd(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x38 && buf[1] == 0x42 && buf[2] == 0x50 && buf[3] == 0x53
 }
 
 /// Returns whether a buffer is ICO icon image data.
+#[must_use]
 pub fn is_ico(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x00 && buf[1] == 0x00 && buf[2] == 0x01 && buf[3] == 0x00
 }
 
 /// Returns whether a buffer is JPEG XL (JXL) image data.
+#[must_use]
 pub fn is_jxl(buf: &[u8]) -> bool {
     (buf.len() > 2 && buf[0] == 0xFF && buf[1] == 0x0A)
         || (buf.len() > 12
@@ -97,6 +109,7 @@ pub fn is_jxl(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is HEIF image data.
+#[must_use]
 pub fn is_heif(buf: &[u8]) -> bool {
     if buf.is_empty() {
         return false;
@@ -124,6 +137,7 @@ pub fn is_heif(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is AVIF image data.
+#[must_use]
 pub fn is_avif(buf: &[u8]) -> bool {
     if buf.is_empty() {
         return false;
@@ -162,6 +176,8 @@ fn is_isobmff(buf: &[u8]) -> bool {
     buf.len() >= ftyp_length
 }
 
+/// Returns whether a buffer is `ORA` image data.
+#[must_use]
 pub fn is_ora(buf: &[u8]) -> bool {
     buf.len() > 57
         && buf[0] == 0x50
@@ -194,7 +210,8 @@ pub fn is_ora(buf: &[u8]) -> bool {
         && buf[53] == 0x72
 }
 
-/// Returns whether a buffer is DjVu image data.
+/// Returns whether a buffer is `DjVu` image data.
+#[must_use]
 pub fn is_djvu(buf: &[u8]) -> bool {
     buf.len() > 14
         && buf[0] == 0x41

--- a/src/matchers/odf.rs
+++ b/src/matchers/odf.rs
@@ -7,17 +7,20 @@ enum DocType {
     Presentation,
 }
 
-/// Returns whether a buffer is OpenDocument Text
+/// Returns whether a buffer is `OpenDocument` Text
+#[must_use]
 pub fn is_odt(buf: &[u8]) -> bool {
     odf(buf) == Some(DocType::Text)
 }
 
-/// Returns whether a buffer is OpenDocument Spreadsheet
+/// Returns whether a buffer is `OpenDocument` Spreadsheet
+#[must_use]
 pub fn is_ods(buf: &[u8]) -> bool {
     odf(buf) == Some(DocType::Spreadsheet)
 }
 
-/// Returns whether a buffer is OpenDocument Presentation
+/// Returns whether a buffer is `OpenDocument` Presentation
+#[must_use]
 pub fn is_odp(buf: &[u8]) -> bool {
     odf(buf) == Some(DocType::Presentation)
 }

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -52,7 +52,7 @@ pub fn is_xml(buf: &[u8]) -> bool {
 
 /// Strip whitespaces at the beginning of the buffer.
 ///
-/// Follows `https://mimesniff.spec.whatwg.org`
+/// Follows <https://mimesniff.spec.whatwg.org>
 /// definition of whitespace.
 fn trim_start_whitespaces(mut buf: &[u8]) -> &[u8] {
     while !buf.is_empty() {

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -2,6 +2,7 @@
 ///
 /// Conforms to [whatwg](https://mimesniff.spec.whatwg.org/)
 /// specification.
+#[must_use]
 pub fn is_html(buf: &[u8]) -> bool {
     let values: &[&[u8]] = &[
         b"<!DOCTYPE HTML",
@@ -29,7 +30,7 @@ pub fn is_html(buf: &[u8]) -> bool {
             match buf[val.len()] {
                 // tag-terminitating byte
                 0x20 | 0x3E => return true,
-                _ => continue,
+                _ => {}
             }
         }
     }
@@ -41,6 +42,7 @@ pub fn is_html(buf: &[u8]) -> bool {
 ///
 /// Conforms to [whatwg](https://mimesniff.spec.whatwg.org/)
 /// specification.
+#[must_use]
 pub fn is_xml(buf: &[u8]) -> bool {
     let val: &[u8] = b"<?xml";
     let buf = trim_start_whitespaces(buf);
@@ -50,7 +52,7 @@ pub fn is_xml(buf: &[u8]) -> bool {
 
 /// Strip whitespaces at the beginning of the buffer.
 ///
-/// Follows https://mimesniff.spec.whatwg.org
+/// Follows `https://mimesniff.spec.whatwg.org`
 /// definition of whitespace.
 fn trim_start_whitespaces(mut buf: &[u8]) -> &[u8] {
     while !buf.is_empty() {
@@ -66,9 +68,8 @@ fn trim_start_whitespaces(mut buf: &[u8]) -> &[u8] {
 fn trim_start_byte_order_marks(mut buf: &[u8]) -> &[u8] {
     while buf.len() >= 3 {
         match (buf[0], buf[1], buf[2]) {
-            (0xEF, 0xBB, 0xBF) => buf = &buf[3..], // UTF-8
-            (0xFE, 0xFF, _) => buf = &buf[2..],    // UTF-16 BE
-            (0xFF, 0xFE, _) => buf = &buf[2..],    // UTF-16 BE
+            (0xEF, 0xBB, 0xBF) => buf = &buf[3..],                // UTF-8
+            (0xFE, 0xFF, _) | (0xFF, 0xFE, _) => buf = &buf[2..], // UTF-16 BE
             _ => break,
         }
     }
@@ -80,6 +81,7 @@ fn starts_with_ignore_ascii_case(buf: &[u8], needle: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is a shell script.
+#[must_use]
 pub fn is_shellscript(buf: &[u8]) -> bool {
     buf.len() > 2 && &buf[..2] == b"#!"
 }

--- a/src/matchers/video.rs
+++ b/src/matchers/video.rs
@@ -1,4 +1,5 @@
 /// Returns whether a buffer is M4V video data.
+#[must_use]
 pub fn is_m4v(buf: &[u8]) -> bool {
     buf.len() > 10
         && buf[4] == 0x66
@@ -11,6 +12,7 @@ pub fn is_m4v(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is MKV video data.
+#[must_use]
 pub fn is_mkv(buf: &[u8]) -> bool {
     (buf.len() > 15
         && buf[0] == 0x1A
@@ -41,11 +43,13 @@ pub fn is_mkv(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is WEBM video data.
+#[must_use]
 pub fn is_webm(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x1A && buf[1] == 0x45 && buf[2] == 0xDF && buf[3] == 0xA3
 }
 
 /// Returns whether a buffer is Quicktime MOV video data.
+#[must_use]
 pub fn is_mov(buf: &[u8]) -> bool {
     buf.len() > 15
         && (((buf[4] == b'f' && buf[5] == b't' && buf[6] == b'y' && buf[7] == b'p')
@@ -56,6 +60,7 @@ pub fn is_mov(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is AVI video data.
+#[must_use]
 pub fn is_avi(buf: &[u8]) -> bool {
     buf.len() > 10
         && buf[0] == 0x52
@@ -68,6 +73,7 @@ pub fn is_avi(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is WMV video data.
+#[must_use]
 pub fn is_wmv(buf: &[u8]) -> bool {
     buf.len() > 9
         && buf[0] == 0x30
@@ -83,6 +89,7 @@ pub fn is_wmv(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is MPEG video data.
+#[must_use]
 pub fn is_mpeg(buf: &[u8]) -> bool {
     buf.len() > 3
         && buf[0] == 0x0
@@ -93,11 +100,13 @@ pub fn is_mpeg(buf: &[u8]) -> bool {
 }
 
 /// Returns whether a buffer is FLV video data.
+#[must_use]
 pub fn is_flv(buf: &[u8]) -> bool {
     buf.len() > 3 && buf[0] == 0x46 && buf[1] == 0x4C && buf[2] == 0x56 && buf[3] == 0x01
 }
 
 /// Returns whether a buffer is MP4 video data.
+#[must_use]
 pub fn is_mp4(buf: &[u8]) -> bool {
     buf.len() > 11
         && (buf[4] == b'f' && buf[5] == b't' && buf[6] == b'y' && buf[7] == b'p')


### PR DESCRIPTION
Hi, 

This PR fixes every Clippy pedantic warnings, ~~removes unnecessary unwraps (is_zst and is_lz4)~~, update dependencies (cfb) and add cargo miri to CI.

Please note that version in Cargo.toml has been bumped to **0.21.0** but crates.io's version and current tag is still **0.19.0**. I can of course change this back to **0.20.0** if master's version is not synced.

Please also note that Rust edition has been bumped to 2024.

PS: if you are looking for co-maintainers for this crate, I'd be glad to help a bit :) 