### PR TITLE
feat: support xml+svg and svg

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -227,6 +227,12 @@ matcher_map!(
         "dwg",
         matchers::image::is_dwg
     ),
+    (
+        MatcherType::Image,
+        "image/svg+xml",
+        "svg",
+        matchers::image::is_svg
+    ),
     // Video
     (
         MatcherType::Video,

--- a/src/matchers/image.rs
+++ b/src/matchers/image.rs
@@ -227,6 +227,25 @@ pub fn is_djvu(buf: &[u8]) -> bool {
         && buf[14] == 0x56
 }
 
+/// Returns whether a buffer is SVG image data.
+#[must_use]
+pub fn is_svg(buf: &[u8]) -> bool {
+    if buf.starts_with(b"<svg") {
+        return true;
+    }
+
+    // Avoid conflicts with other XML types while detecting SVGs.
+    if buf.starts_with(b"<?xml") {
+        return buf
+            .get(..256)
+            .unwrap_or(buf)
+            .windows(4)
+            .any(|w| w == b"<svg");
+    }
+
+    false
+}
+
 /// Returns whether a buffer is an AutoCAD Drawing (DWG).
 #[must_use]
 pub fn is_dwg(buf: &[u8]) -> bool {

--- a/src/matchers/text.rs
+++ b/src/matchers/text.rs
@@ -47,7 +47,7 @@ pub fn is_xml(buf: &[u8]) -> bool {
     let val: &[u8] = b"<?xml";
     let buf = trim_start_whitespaces(buf);
     let buf = trim_start_byte_order_marks(buf);
-    starts_with_ignore_ascii_case(buf, val)
+    starts_with_ignore_ascii_case(buf, val) && !super::image::is_svg(buf) // try avoid detecting XML-declared SVGs
 }
 
 /// Strip whitespaces at the beginning of the buffer.
@@ -88,7 +88,7 @@ pub fn is_shellscript(buf: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_html, is_shellscript, trim_start_whitespaces};
+    use super::{is_html, is_shellscript, is_xml, trim_start_whitespaces};
 
     #[test]
     fn trim_whitespaces() {
@@ -113,5 +113,13 @@ mod tests {
     #[test]
     fn shellscript() {
         assert!(!is_shellscript(b"#!"));
+    }
+
+    #[test]
+    fn xml_excludes_svg() {
+        assert!(!is_xml(
+            b"<?xml version=\"1.0\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\">"
+        ));
+        assert!(is_xml(b"<?xml version=\"1.0\"?>\n<note/>"));
     }
 }

--- a/testdata/sample.svg
+++ b/testdata/sample.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="5"/>
+</svg>

--- a/testdata/sample2.svg
+++ b/testdata/sample2.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="5"/>
+</svg>

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -37,3 +37,7 @@ test_format!(Image, "image/vnd.djvu", "djvu", djvu1, "sample_single.djvu");
 test_format!(Image, "image/vnd.djvu", "djvu", djvu2, "sample_multi.djvu");
 
 test_format!(Image, "image/vnd.dwg", "dwg", dwg, "sample.dwg");
+
+test_format!(Image, "image/svg+xml", "svg", svg, "sample.svg");
+
+test_format!(Image, "image/svg+xml", "svg", svg2, "sample2.svg");


### PR DESCRIPTION
This PR is a more complete implementation of SVG support that supersedes #115 and #73.

This matcher is correctly able to detect both <svg> and <xml>+<svg> combinations by reading ahead in the buffer by up to 256 bytes when an xml tag is detected - this read-ahead amount _should_ be low enough to avoid false detections in other file formats while still detecting XML+SVG correctly.

Two sample files have been been added alongside test cases for both SVG detections and for ensuring text-based XML still works as expected by excluding SVG.

resolves #60