### PR TITLE
Avoid recursion in zstd skippable frame detection

### DIFF
--- a/src/matchers/archive.rs
+++ b/src/matchers/archive.rs
@@ -275,34 +275,42 @@ const ZSTD_SKIP_MASK: usize = 0xFFFF_FFF0;
 /// by the preceding check of `buf.len()` < 8
 #[must_use]
 pub fn is_zst(buf: &[u8]) -> bool {
-    if buf.len() > 3 && buf[0] == 0x28 && buf[1] == 0xB5 && buf[2] == 0x2F && buf[3] == 0xFD {
-        return true;
+    let mut frame = buf;
+
+    loop {
+        if frame.len() > 3
+            && frame[0] == 0x28
+            && frame[1] == 0xB5
+            && frame[2] == 0x2F
+            && frame[3] == 0xFD
+        {
+            return true;
+        }
+
+        if frame.len() < 8 {
+            return false;
+        }
+
+        let magic = u32::from_le_bytes(frame[0..4].try_into().unwrap());
+        let Ok(magic) = usize::try_from(magic) else {
+            return false;
+        };
+
+        if magic & ZSTD_SKIP_MASK != ZSTD_SKIP_START {
+            return false;
+        }
+
+        let data_len = u32::from_le_bytes(frame[4..8].try_into().unwrap());
+        let Ok(data_len) = usize::try_from(data_len) else {
+            return false;
+        };
+
+        if frame.len() < 8 + data_len {
+            return false;
+        }
+
+        frame = &frame[8 + data_len..];
     }
-
-    if buf.len() < 8 {
-        return false;
-    }
-
-    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
-    let Ok(magic) = usize::try_from(magic) else {
-        return false;
-    };
-
-    if magic & ZSTD_SKIP_MASK != ZSTD_SKIP_START {
-        return false;
-    }
-
-    let data_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
-    let Ok(data_len) = usize::try_from(data_len) else {
-        return false;
-    };
-
-    if buf.len() < 8 + data_len {
-        return false;
-    }
-
-    let next_frame = &buf[8 + data_len..];
-    is_zst(next_frame)
 }
 
 /// Returns whether a buffer is a LZ4 archive.

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -26,3 +26,21 @@ test_format!(
     "sample.skippable.zst"
 );
 test_format!(Archive, "application/x-par2", "par2", par2, "sample.par2");
+
+#[test]
+fn zstd_many_empty_skippable_frames_do_not_recurse() {
+    let mut input = Vec::new();
+    for _ in 0..50_000 {
+        input.extend_from_slice(&[0x50, 0x2A, 0x4D, 0x18, 0, 0, 0, 0]);
+    }
+
+    assert!(!infer::archive::is_zst(&input));
+}
+
+#[test]
+fn zstd_skippable_frames_before_real_frame_match() {
+    let mut input = Vec::from([0x50, 0x2A, 0x4D, 0x18, 0, 0, 0, 0]);
+    input.extend_from_slice(&[0x28, 0xB5, 0x2F, 0xFD]);
+
+    assert!(infer::archive::is_zst(&input));
+}


### PR DESCRIPTION
## Summary

This changes Zstandard skippable-frame detection to iterate instead of recursively calling `is_zst` for each skippable frame.

A crafted input with many empty skippable frames currently consumes one stack frame per 8 input bytes. In optimized builds LLVM may eliminate the tail recursion, but Rust does not guarantee tail-call elimination and debug/sanitized/instrumented builds can still overflow the stack.

## Changes

- Replace recursive zstd skippable-frame traversal with a loop.
- Add regression coverage for many empty skippable frames.
- Preserve matching behavior for skippable frames followed by a real zstd frame.


## Tests

- `cargo fmt --check`
- `cargo test zstd`

## Root Cause Analysis

`is_zst` handles leading Zstandard skippable frames with direct self-recursion. For zero-length skippable frames, each recursive call consumes only the 8-byte skippable-frame header, so recursion depth is proportional to input size.

Rust does not guarantee tail-call elimination, so this can cause stack exhaustion in builds where the compiler does not optimize the recursion into a loop.

## Description

The Zstandard matcher reads:

1. a 4-byte magic value,
2. a 4-byte little-endian skippable-frame length,
3. then recurses on the remaining buffer after the skippable frame.

For a zero-length skippable frame, the input advances by exactly 8 bytes:

`50 2A 4D 18 00 00 00 00`

A buffer made of repeated zero-length skippable frames can therefore cause one recursive call per 8 bytes of input. With sufficiently large input, downstream users building without tail-call optimization may hit stack exhaustion.
This patch rewrites the recursive walk as an explicit loop. The parsing behavior is unchanged, but the matcher no longer depends on compiler tail-call optimization for stack safety.

## Intended Behavior
`is_zst` should identify Zstandard data by skipping any leading skippable frames and returning true only if a real Zstandard frame is eventually found. Per RFC 8478, a Zstandard stream may begin with one or more skippable frames before the real Zstandard frame. Skipping those frames should be bounded by input length and implemented iteratively rather than recursively.

## Conditions
This issue is relevant when infer is used on untrusted or large buffers and is built in an environment where recursive calls are not optimized into a loop, such as debug builds, sanitizer builds, coverage/instrumented builds, or downstream compiler configurations with lower optimization levels. Optimized builds may avoid the stack growth today, but that behavior is not guaranteed by Rust or by the library API contract.