### PR TITLE
Avoid recursion in LZ4 skippable-frame detection

### DIFF
--- a/src/matchers/archive.rs
+++ b/src/matchers/archive.rs
@@ -319,35 +319,43 @@ pub fn is_zst(buf: &[u8]) -> bool {
 // See more details from https://github.com/lz4/lz4/blob/v1.9.4/doc/lz4_Frame_format.md
 #[must_use]
 pub fn is_lz4(buf: &[u8]) -> bool {
-    // LZ4 frame magic
-    if buf.len() > 3 && buf[0] == 0x04 && buf[1] == 0x22 && buf[2] == 0x4D && buf[3] == 0x18 {
-        return true;
+    let mut frame = buf;
+
+    loop {
+        // LZ4 frame magic.
+        if frame.len() > 3
+            && frame[0] == 0x04
+            && frame[1] == 0x22
+            && frame[2] == 0x4D
+            && frame[3] == 0x18
+        {
+            return true;
+        }
+
+        if frame.len() < 8 {
+            return false;
+        }
+
+        let magic = u32::from_le_bytes(frame[0..4].try_into().unwrap());
+        let Ok(magic) = usize::try_from(magic) else {
+            return false;
+        };
+
+        if magic & ZSTD_SKIP_MASK != ZSTD_SKIP_START {
+            return false;
+        }
+
+        let data_len = u32::from_le_bytes(frame[4..8].try_into().unwrap());
+        let Ok(data_len) = usize::try_from(data_len) else {
+            return false;
+        };
+
+        if frame.len() < 8 + data_len {
+            return false;
+        }
+
+        frame = &frame[8 + data_len..];
     }
-
-    if buf.len() < 8 {
-        return false;
-    }
-
-    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
-    let Ok(magic) = usize::try_from(magic) else {
-        return false;
-    };
-
-    if magic & ZSTD_SKIP_MASK != ZSTD_SKIP_START {
-        return false;
-    }
-
-    let data_len = u32::from_le_bytes(buf[4..8].try_into().unwrap());
-    let Ok(data_len) = usize::try_from(data_len) else {
-        return false;
-    };
-
-    if buf.len() < 8 + data_len {
-        return false;
-    }
-
-    let next_frame = &buf[8 + data_len..];
-    is_lz4(next_frame)
 }
 
 /// Returns whether a buffer is a MSI Windows Installer archive.

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -44,3 +44,21 @@ fn zstd_skippable_frames_before_real_frame_match() {
 
     assert!(infer::archive::is_zst(&input));
 }
+
+#[test]
+fn lz4_many_empty_skippable_frames_do_not_recurse() {
+    let mut input = Vec::new();
+    for _ in 0..50_000 {
+        input.extend_from_slice(&[0x50, 0x2A, 0x4D, 0x18, 0, 0, 0, 0]);
+    }
+
+    assert!(!infer::archive::is_lz4(&input));
+}
+
+#[test]
+fn lz4_skippable_frames_before_real_frame_match() {
+    let mut input = Vec::from([0x50, 0x2A, 0x4D, 0x18, 0, 0, 0, 0]);
+    input.extend_from_slice(&[0x04, 0x22, 0x4D, 0x18]);
+
+    assert!(infer::archive::is_lz4(&input));
+}


### PR DESCRIPTION
Follow up on https://github.com/bojand/infer/pull/124

Same issue for the Lz4 type and same fix applied. 

## Summary
This changes lz4 type skippable-frame detection to iterate instead of recursively calling is_lz4 for each skippable frame.

A crafted input with many empty skippable frames currently consumes one stack frame per 8 input bytes. In optimized builds LLVM may eliminate the tail recursion, but Rust does not guarantee tail-call elimination and debug/sanitized/instrumented builds can still overflow the stack.

## Changes
- Replace recursive lz4 skippable-frame traversal with a loop.
- Add regression coverage for many empty skippable frames.